### PR TITLE
Use tabs for indentation on bootstrap template

### DIFF
--- a/ginkgo/templates.go
+++ b/ginkgo/templates.go
@@ -27,8 +27,8 @@ var specText = `package {{.Package}}_test
 
 import (
 	. "{{.PackageImportPath}}"
-    . "github.com/onsi/ginkgo"
-    . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("{{.Subject}}", func() {


### PR DESCRIPTION
You can't make it out in the diff on GitHub, but the import statements for ginkgo and gomega had leading spaces; this PR changes the spaces to tabs.
