### PR TITLE
getPackageImportPath now gets the last path after splitting src

### DIFF
--- a/ginkgo/templates.go
+++ b/ginkgo/templates.go
@@ -126,10 +126,7 @@ func getPackageImportPath() string {
 		panic(err.Error())
 	}
 	paths := strings.Split(workingDir, "/src/")
-	if len(paths) != 2 {
-		panic("Couldn't identify package import path")
-	}
-	return paths[1]
+	return paths[len(paths) - 1]
 }
 
 func fileExists(path string) bool {


### PR DESCRIPTION
After applying patch locally:

$ ginkgo generate gossh
Generating ginkgo test for Gossh in:
        gossh_test.go
