### PR TITLE
Add an API call for retrieving the current test context stack.

### DIFF
--- a/ginkgo.go
+++ b/ginkgo.go
@@ -252,3 +252,7 @@ func parseTimeout(timeout ...float64) time.Duration {
 		return time.Duration(timeout[0] * float64(time.Second))
 	}
 }
+
+func GetTestContext() []string {
+	return globalSuite.getTestContext()
+}

--- a/suite.go
+++ b/suite.go
@@ -86,3 +86,23 @@ func (suite *suite) pushJustBeforeEachNode(body interface{}, codeLocation types.
 func (suite *suite) pushAfterEachNode(body interface{}, codeLocation types.CodeLocation, timeout time.Duration) {
 	suite.currentContainer.pushAfterEachNode(newRunnableNode(body, codeLocation, timeout))
 }
+
+func (suite *suite) getTestContext() []string {
+	var result []string
+
+	collection := suite.exampleCollection
+	if collection == nil {
+		return result
+	}
+	example := collection.runningExample
+	if example == nil {
+		return result
+	}
+
+	for _, container := range example.containers[1:] {
+		result = append(result, container.getText())
+	}
+	result = append(result, example.subject.getText())
+
+	return result
+}


### PR DESCRIPTION
We have some automated logging that runs off testing, and for diagnostics it's really useful to be able to automatically tie the spew to the test case it was emitted in. My naive hack was to just add an API call to Ginkgo that retrieves the currently running example and returns the list of containers it's in. If there's a better way I'd be happy to do that instead.
