### PR TITLE
Improve converted test descriptions 

### DIFF
--- a/ginkgo/integration/_fixtures/convert_goldmasters/extra_functions_test.go
+++ b/ginkgo/integration/_fixtures/convert_goldmasters/extra_functions_test.go
@@ -9,7 +9,7 @@ func somethingImportant(t GinkgoTestingT, message *string) {
 }
 func init() {
 	Describe("Testing with Ginkgo", func() {
-		It("TestSomethingLessImportant", func() {
+		It("something less important", func() {
 			somethingImportant(GinkgoT(), &"hello!")
 		})
 	})

--- a/ginkgo/integration/_fixtures/convert_goldmasters/nested_subpackage_test.go
+++ b/ginkgo/integration/_fixtures/convert_goldmasters/nested_subpackage_test.go
@@ -6,7 +6,7 @@ import (
 
 func init() {
 	Describe("Testing with Ginkgo", func() {
-		It("TestNestedSubPackages", func() {
+		It("nested sub packages", func() {
 			GinkgoT().Fail(true)
 		})
 	})

--- a/ginkgo/integration/_fixtures/convert_goldmasters/nested_test.go
+++ b/ginkgo/integration/_fixtures/convert_goldmasters/nested_test.go
@@ -6,7 +6,7 @@ import (
 
 func init() {
 	Describe("Testing with Ginkgo", func() {
-		It("TestSomethingLessImportant", func() {
+		It("something less important", func() {
 
 			whatever := &UselessStruct{}
 			GinkgoT().Fail(whatever.ImportantField != "SECRET_PASSWORD")

--- a/ginkgo/integration/_fixtures/convert_goldmasters/outside_package_test.go
+++ b/ginkgo/integration/_fixtures/convert_goldmasters/outside_package_test.go
@@ -10,7 +10,7 @@ type UselessStruct struct {
 
 func init() {
 	Describe("Testing with Ginkgo", func() {
-		It("TestSomethingImportant", func() {
+		It("something important", func() {
 
 			whatever := &UselessStruct{}
 			GinkgoT().Fail(whatever.ImportantField != "SECRET_PASSWORD")

--- a/ginkgo/integration/_fixtures/convert_goldmasters/xunit_test.go
+++ b/ginkgo/integration/_fixtures/convert_goldmasters/xunit_test.go
@@ -13,7 +13,7 @@ var testFunc = func(t GinkgoTestingT, arg *string) {}
 
 func init() {
 	Describe("Testing with Ginkgo", func() {
-		It("TestSomethingImportant", func() {
+		It("something important", func() {
 
 			whatever := &UselessStruct{
 				T:              GinkgoT(),


### PR DESCRIPTION
Given

`func TestConvertsToGinkgo(t *testing.T) { }`

The converted code should be 

`It("converts to ginkgo", func() { })`

Given that unit test names always start with Test and are camel cased, it seemed to me that we could do better to write a much more natural test name for `ginkgo convert`.
