### PR TITLE
Fix bug in the GomockTestReporter

### DIFF
--- a/thirdparty/gomocktestreporter/gomock_test_reporter.go
+++ b/thirdparty/gomocktestreporter/gomock_test_reporter.go
@@ -17,9 +17,9 @@ func New() GomockTestReporter {
 }
 
 func (g GomockTestReporter) Errorf(format string, args ...interface{}) {
-	ginkgo.Fail(fmt.Sprintf(format, args), 3)
+	ginkgo.Fail(fmt.Sprintf(format, args...), 3)
 }
 
 func (g GomockTestReporter) Fatalf(format string, args ...interface{}) {
-	ginkgo.Fail(fmt.Sprintf(format, args), 3)
+	ginkgo.Fail(fmt.Sprintf(format, args...), 3)
 }


### PR DESCRIPTION
The variadic function arguments where passed as array instead of a
regular list of arguments.

This will greatly obfuscate the error messages and result in something like
`no matching expected call: []interface {}.%!v(MISSING)(%!v(MISSING))`

See http://golang.org/doc/effective_go.html#Printing for more details on how to pass variadic function arguments.
