### PR TITLE
change ANSI red color from 91 to 31; add blue and magenta colors

### DIFF
--- a/reporters/stenographer/stenographer.go
+++ b/reporters/stenographer/stenographer.go
@@ -15,12 +15,14 @@ import (
 
 const defaultStyle = "\x1b[0m"
 const boldStyle = "\x1b[1m"
-const redColor = "\x1b[91m"
+const redColor = "\x1b[31m"
 const greenColor = "\x1b[32m"
 const yellowColor = "\x1b[33m"
+//const blueColor = "\x1b[34m"
+//const magentaColor = "\x1b[35m"
 const cyanColor = "\x1b[36m"
-const grayColor = "\x1b[90m"
 const lightGrayColor = "\x1b[37m"
+const grayColor = "\x1b[90m"
 
 type cursorStateType int
 


### PR DESCRIPTION
change ANSI red color from 91 to 31 (91 works in OS X native terminal, but not http://plugins.jetbrains.com/plugin/7125 ; ref http:/. /stackoverflow.com/questions/3219393/stdlib-and-colored-output-in-c) ; add blue and magenta colors add comment in case needed in the future
