### PR TITLE
remove superfluous call to os.IsNotExist

### DIFF
--- a/ginkgo/bootstrap_command.go
+++ b/ginkgo/bootstrap_command.go
@@ -67,9 +67,6 @@ func fileExists(path string) bool {
 	if err == nil {
 		return true
 	}
-	if os.IsNotExist(err) {
-		return false
-	}
 	return false
 }
 


### PR DESCRIPTION
Was just reviewing the bootstrapping process and saw this. Seemed like an unnecessary check.
