### PR TITLE
Make the unkown knowable

### DIFF
--- a/ginkgo/help_command.go
+++ b/ginkgo/help_command.go
@@ -23,7 +23,7 @@ func printHelp(args []string, additionalArgs []string) {
 	} else {
 		command, found := commandMatching(args[0])
 		if !found {
-			complainAndQuit(fmt.Sprintf("Unkown command: %s", args[0]))
+			complainAndQuit(fmt.Sprintf("Unknown command: %s", args[0]))
 		}
 
 		usageForCommand(command, true)

--- a/ginkgo/watch/delta_tracker.go
+++ b/ginkgo/watch/delta_tracker.go
@@ -64,7 +64,7 @@ func (d *DeltaTracker) Delta(suites []testsuite.TestSuite) (delta Delta, errors 
 func (d *DeltaTracker) WillRun(suite testsuite.TestSuite) error {
 	s, ok := d.suites[suite.Path]
 	if !ok {
-		return fmt.Errorf("unkown suite %s", suite.Path)
+		return fmt.Errorf("unknown suite %s", suite.Path)
 	}
 
 	return s.MarkAsRunAndRecomputedDependencies(d.maxDepth)


### PR DESCRIPTION
This pull request fixes a typo that only the most pedantic person would bother fixing.

One small, annoying question I have is whether or not the error in `delta_tracker.go` should also be capitalized for consistency?

e.g.: `return fmt.Errorf("Unknown suite %s", suite.Path)`

It's not clear to me at first glance if that error is ever exposed back to the user.