### PR TITLE
Update Agouti templates for upcoming Agouti 2.0 release

### DIFF
--- a/ginkgo/bootstrap_command.go
+++ b/ginkgo/bootstrap_command.go
@@ -54,7 +54,7 @@ var agoutiBootstrapText = `package {{.Package}}_test
 import (
 	{{.GinkgoImport}}
 	{{.GomegaImport}}
-	. "github.com/sclevine/agouti/core"
+	"github.com/sclevine/agouti"
 
 	"testing"
 )
@@ -64,23 +64,20 @@ func Test{{.FormattedName}}(t *testing.T) {
 	RunSpecs(t, "{{.FormattedName}} Suite")
 }
 
-var agoutiDriver WebDriver
+var agoutiDriver *agouti.WebDriver
 
 var _ = BeforeSuite(func() {
-	var err error
-
 	// Choose a WebDriver:
 
-	agoutiDriver, err = PhantomJS()
-	// agoutiDriver, err = Selenium()
-	// agoutiDriver, err = Chrome()
+	agoutiDriver = agouti.PhantomJS()
+	// agoutiDriver = agouti.Selenium()
+	// agoutiDriver = agouti.ChromeDriver()
 
-	Expect(err).NotTo(HaveOccurred())
 	Expect(agoutiDriver.Start()).To(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	agoutiDriver.Stop()
+	Expect(agoutiDriver.Stop()).To(Succeed())
 })
 `
 

--- a/ginkgo/generate_command.go
+++ b/ginkgo/generate_command.go
@@ -51,21 +51,21 @@ import (
 
 	{{if .IncludeImports}}. "github.com/onsi/ginkgo"{{end}}
 	{{if .IncludeImports}}. "github.com/onsi/gomega"{{end}}
-	. "github.com/sclevine/agouti/core"
 	. "github.com/sclevine/agouti/matchers"
+	"github.com/sclevine/agouti"
 )
 
 var _ = Describe("{{.Subject}}", func() {
-	var page Page
+	var page *agouti.Page
 
 	BeforeEach(func() {
 		var err error
-		page, err = agoutiDriver.Page()
+		page, err = agoutiDriver.NewPage()
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		page.Destroy()
+		Expect(page.Destroy()).To(Succeed())
 	})
 })
 `

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Subcommand", func() {
 
 			Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/ginkgo"`))
 			Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/gomega"`))
-			Ω(content).Should(ContainSubstring("\t" + `. "github.com/sclevine/agouti/core"`))
+			Ω(content).Should(ContainSubstring("\t" + `"github.com/sclevine/agouti"`))
 		})
 	})
 
@@ -256,9 +256,9 @@ var _ = Describe("Subcommand", func() {
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/ginkgo"`))
 				Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/gomega"`))
-				Ω(content).Should(ContainSubstring("\t" + `. "github.com/sclevine/agouti/core"`))
 				Ω(content).Should(ContainSubstring("\t" + `. "github.com/sclevine/agouti/matchers"`))
-				Ω(content).Should(ContainSubstring("page, err = agoutiDriver.Page()"))
+				Ω(content).Should(ContainSubstring("\t" + `"github.com/sclevine/agouti"`))
+				Ω(content).Should(ContainSubstring("page, err = agoutiDriver.NewPage()"))
 			})
 		})
 	})


### PR DESCRIPTION
Agouti 2.0 deprecates the `agouti/core` package in favor a more gopher-friendly interface in `agouti`.
The `agouti/core` package will continue to exist for now, but I'm still waiting until this PR gets merged before I merge the Agouti 2.0 branch into master.