### PR TITLE
Use two dashes for test.timeout argument.

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -291,7 +291,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 }
 
 func (t *TestRunner) cmd(ginkgoArgs []string, stream io.Writer, node int) *exec.Cmd {
-	args := []string{"-test.timeout=24h"}
+	args := []string{"--test.timeout=24h"}
 	if t.cover {
 		coverprofile := "--test.coverprofile=" + t.Suite.PackageName + ".coverprofile"
 		if t.numCPU > 1 {


### PR DESCRIPTION
Alternate flag libraries such as github.com/spf13/pflag add support for
shorthand flags. This causes `-test.timeout` to be interpreted as the
shorthand flag `t` rather than the longhand flag `test.timeout`.

Using two dashes avoids this issue.