### PR TITLE
go 1.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.2
   - 1.3
   - 1.4
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
+  - 1.2
+  - 1.3
   - 1.4
+  - tip
 
 install:
   - go get -v ./...

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -100,9 +100,28 @@ func (t *TestRunner) CompileTo(path string) error {
 		return fmt.Errorf("Failed to compile %s", t.Suite.PackageName)
 	}
 
+	if fileExists(path) == false {
+		compiledFile := filepath.Join(t.Suite.Path, t.Suite. PackageName+".test")
+		if fileExists(compiledFile) {
+			// seems like we are on an old go version that does not support the -o flag on go test
+			// move the compiled test file to the desired location by hand
+			err = os.Rename(compiledFile, path)
+			if err != nil {
+				return fmt.Errorf("Failed to move compiled file: %s", err)
+			}
+		} else {
+			return fmt.Errorf("Failed to compile %s: output file %q could not be found", t.Suite.PackageName, path)
+		}
+	}
+
 	t.compiled = true
 
 	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || os.IsNotExist(err) == false
 }
 
 /*

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Running Specs", func() {
 				Eventually(session).Should(gexec.Exit(0))
 				output := string(session.Out.Contents())
 
-				Ω(output).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs - 2 nodes •••• SUCCESS! [\d.µs]+`))
+				Ω(output).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs - 2 nodes •••• SUCCESS! \d+(\.\d+)[muµ]s`))
 				Ω(output).Should(ContainSubstring("Test Suite Passed"))
 			})
 		})
@@ -232,7 +232,7 @@ var _ = Describe("Running Specs", func() {
 				if nodes > 4 {
 					nodes = nodes - 1
 				}
-				Ω(output).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs - %d nodes •••• SUCCESS! [\d.µs]+`, nodes))
+				Ω(output).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs - %d nodes •••• SUCCESS! \d+(\.\d+)[muµ]s`, nodes))
 				Ω(output).Should(ContainSubstring("Test Suite Passed"))
 			})
 		})
@@ -272,8 +272,8 @@ var _ = Describe("Running Specs", func() {
 				output := string(session.Out.Contents())
 
 				outputLines := strings.Split(output, "\n")
-				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! [\d.µs]+ PASS`))
-				Ω(outputLines[1]).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs •• SUCCESS! [\d.µs]+ PASS`))
+				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! \d+(\.\d+)[muµ]s PASS`))
+				Ω(outputLines[1]).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs •• SUCCESS! \d+(\.\d+)[muµ]s PASS`))
 				Ω(output).Should(ContainSubstring("Test Suite Passed"))
 			})
 		})
@@ -290,7 +290,7 @@ var _ = Describe("Running Specs", func() {
 				output := string(session.Out.Contents())
 
 				outputLines := strings.Split(output, "\n")
-				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! [\d.µs]+ PASS`))
+				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! \d+(\.\d+)[muµ]s PASS`))
 				Ω(outputLines[1]).Should(MatchRegexp(`\[\d+\] Failing_ginkgo_tests Suite - 2/2 specs`))
 				Ω(output).Should(ContainSubstring("• Failure"))
 				Ω(output).ShouldNot(ContainSubstring("More_ginkgo_tests Suite"))
@@ -313,7 +313,7 @@ var _ = Describe("Running Specs", func() {
 				output := string(session.Out.Contents())
 
 				outputLines := strings.Split(output, "\n")
-				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! [\d.µs]+ PASS`))
+				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! \d+(\.\d+)[muµ]s PASS`))
 				Ω(outputLines[1]).Should(ContainSubstring("Failed to compile C:"))
 				Ω(output).ShouldNot(ContainSubstring("More_ginkgo_tests Suite"))
 				Ω(output).Should(ContainSubstring("Test Suite Failed"))
@@ -335,11 +335,11 @@ var _ = Describe("Running Specs", func() {
 				output := string(session.Out.Contents())
 
 				outputLines := strings.Split(output, "\n")
-				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! [\d.µs]+ PASS`))
+				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs •••• SUCCESS! \d+(\.\d+)[muµ]s PASS`))
 				Ω(outputLines[1]).Should(ContainSubstring("Failed to compile B:"))
 				Ω(output).Should(MatchRegexp(`\[\d+\] Failing_ginkgo_tests Suite - 2/2 specs`))
 				Ω(output).Should(ContainSubstring("• Failure"))
-				Ω(output).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs •• SUCCESS! [\d.µs]+ PASS`))
+				Ω(output).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs •• SUCCESS! \d+(\.\d+)[muµ]s PASS`))
 				Ω(output).Should(ContainSubstring("Test Suite Failed"))
 			})
 		})


### PR DESCRIPTION
As discussed in #156 this fixes ginkgo when running on go 1.3 where the `-o` flag of test does not work.

If you run `go test -c -o foo.test` on an older go version it will not cause an error but just silently ignore the flag. I resolved the issue by checking if the compilation was successful but the compiled output did not exist on the requested target destination. If this is the case we can assume that `o` did not work and move the file by hand.

The code should bve covered by travis since I added older go versions in the build matrix.
Before I could start I had to fix another issue that made my tests fail (6412c76).
The problem there was that the actual test output was not in the expected format and sometimes failed.

If you want I can split up this PR into two.