### PR TITLE
Add Skip to DSL to allow skipping at runtime

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type DefaultReporterConfigType struct {
 	NoColor           bool
 	SlowSpecThreshold float64
 	NoisyPendings     bool
+	NoisySkippings    bool
 	Succinct          bool
 	Verbose           bool
 	FullTrace         bool
@@ -81,6 +82,7 @@ func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
 	flagSet.BoolVar(&(DefaultReporterConfig.NoColor), prefix+"noColor", false, "If set, suppress color output in default reporter.")
 	flagSet.Float64Var(&(DefaultReporterConfig.SlowSpecThreshold), prefix+"slowSpecThreshold", 5.0, "(in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter (default: 5 seconds).")
 	flagSet.BoolVar(&(DefaultReporterConfig.NoisyPendings), prefix+"noisyPendings", true, "If set, default reporter will shout about pending tests.")
+	flagSet.BoolVar(&(DefaultReporterConfig.NoisySkippings), prefix+"noisySkippings", true, "If set, default reporter will shout about skipping tests.")
 	flagSet.BoolVar(&(DefaultReporterConfig.Verbose), prefix+"v", false, "If set, default reporter print out all specs as they begin.")
 	flagSet.BoolVar(&(DefaultReporterConfig.Succinct), prefix+"succinct", false, "If set, default reporter prints out a very succinct report")
 	flagSet.BoolVar(&(DefaultReporterConfig.FullTrace), prefix+"trace", false, "If set, default reporter prints out the full stack trace when a failure occurs")
@@ -152,6 +154,10 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 
 	if !reporter.NoisyPendings {
 		result = append(result, fmt.Sprintf("--%snoisyPendings=false", prefix))
+	}
+
+	if !reporter.NoisySkippings {
+		result = append(result, fmt.Sprintf("--%snoisySkippings=false", prefix))
 	}
 
 	if reporter.Verbose {

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -222,6 +222,17 @@ func buildDefaultReporter() Reporter {
 	}
 }
 
+//Skip notifies Ginkgo that the current spec was skipped.
+func Skip(message string, callerSkip ...int) {
+	skip := 0
+	if len(callerSkip) > 0 {
+		skip = callerSkip[0]
+	}
+
+	globalFailer.Skip(message, codelocation.New(skip+1))
+	panic(GINKGO_PANIC)
+}
+
 //Fail notifies Ginkgo that the current spec has failed. (Gomega will call Fail for you automatically when an assertion fails.)
 func Fail(message string, callerSkip ...int) {
 	skip := 0

--- a/integration/_fixtures/skip_fixture/skip_fixture_suite_test.go
+++ b/integration/_fixtures/skip_fixture/skip_fixture_suite_test.go
@@ -1,0 +1,13 @@
+package fail_fixture_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestFail_fixture(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Skip_fixture Suite")
+}

--- a/integration/_fixtures/skip_fixture/skip_fixture_test.go
+++ b/integration/_fixtures/skip_fixture/skip_fixture_test.go
@@ -1,0 +1,72 @@
+package fail_fixture_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = It("handles top level skips", func() {
+	Skip("a top level skip on line 9")
+	println("NEVER SEE THIS")
+})
+
+var _ = It("handles async top level skips", func(done Done) {
+	Skip("an async top level skip on line 14")
+	println("NEVER SEE THIS")
+}, 0.1)
+
+var _ = It("SKIP in a goroutine", func(done Done) {
+	go func() {
+		defer GinkgoRecover()
+		Skip("a top level goroutine skip on line 21")
+		println("NEVER SEE THIS")
+	}()
+}, 0.1)
+
+var _ = Describe("Excercising different skip modes", func() {
+	It("synchronous skip", func() {
+		Skip("a sync SKIP")
+		println("NEVER SEE THIS")
+	})
+
+	It("async skip", func(done Done) {
+		Skip("an async SKIP")
+		println("NEVER SEE THIS")
+	}, 0.1)
+
+	It("SKIP in a goroutine", func(done Done) {
+		go func() {
+			defer GinkgoRecover()
+			Skip("a goroutine SKIP")
+			println("NEVER SEE THIS")
+		}()
+	}, 0.1)
+
+	Measure("a SKIP measure", func(Benchmarker) {
+		Skip("a measure SKIP")
+		println("NEVER SEE THIS")
+	}, 1)
+})
+
+
+var _ = Describe("SKIP in a BeforeEach", func() {
+	BeforeEach(func() {
+		Skip("a BeforeEach SKIP")
+		println("NEVER SEE THIS")
+	})
+
+	It("a SKIP BeforeEach", func() {
+		println("NEVER SEE THIS")
+	})
+})
+
+var _ = Describe("SKIP in an AfterEach", func() {
+	AfterEach(func() {
+		Skip("an AfterEach SKIP")
+		println("NEVER SEE THIS")
+	})
+
+	It("a SKIP AfterEach", func() {
+		Expect(true).To(BeTrue())
+	})
+})

--- a/integration/skip_test.go
+++ b/integration/skip_test.go
@@ -1,0 +1,43 @@
+package integration_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Skipping Specs", func() {
+	var pathToTest string
+
+	BeforeEach(func() {
+		pathToTest = tmpPath("skipping")
+		copyIn("skip_fixture", pathToTest)
+	})
+
+	It("should skip in all the possible ways", func() {
+		session := startGinkgo(pathToTest, "--noColor")
+		Eventually(session).Should(gexec.Exit(0))
+		output := string(session.Out.Contents())
+
+		Ω(output).ShouldNot(ContainSubstring("NEVER SEE THIS"))
+
+		Ω(output).Should(ContainSubstring("a top level skip on line 9"))
+		Ω(output).Should(ContainSubstring("skip_fixture_test.go:9"))
+		Ω(output).Should(ContainSubstring("an async top level skip on line 14"))
+		Ω(output).Should(ContainSubstring("skip_fixture_test.go:14"))
+		Ω(output).Should(ContainSubstring("a top level goroutine skip on line 21"))
+		Ω(output).Should(ContainSubstring("skip_fixture_test.go:21"))
+
+		Ω(output).Should(ContainSubstring("a sync SKIP"))
+		Ω(output).Should(ContainSubstring("an async SKIP"))
+		Ω(output).Should(ContainSubstring("a goroutine SKIP"))
+		Ω(output).Should(ContainSubstring("a measure SKIP"))
+
+		Ω(output).Should(ContainSubstring("S [SKIPPING] in Spec Setup (BeforeEach) ["))
+		Ω(output).Should(ContainSubstring("a BeforeEach SKIP"))
+		Ω(output).Should(ContainSubstring("S [SKIPPING] in Spec Teardown (AfterEach) ["))
+		Ω(output).Should(ContainSubstring("an AfterEach SKIP"))
+
+		Ω(output).Should(ContainSubstring("0 Passed | 0 Failed | 0 Pending | 9 Skipped"))
+	})
+})

--- a/internal/failer/failer.go
+++ b/internal/failer/failer.go
@@ -77,3 +77,16 @@ func (f *Failer) Drain(componentType types.SpecComponentType, componentIndex int
 
 	return failure, outcome
 }
+
+func (f *Failer) Skip(message string, location types.CodeLocation) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.state == types.SpecStatePassed {
+		f.state = types.SpecStateSkipped
+		f.failure = types.SpecFailure{
+			Message:  message,
+			Location: location,
+		}
+	}
+}

--- a/internal/failer/failer_test.go
+++ b/internal/failer/failer_test.go
@@ -30,6 +30,22 @@ var _ = Describe("Failer", func() {
 		})
 	})
 
+	Describe("Skip", func() {
+		It("should handle failures", func() {
+			failer.Skip("something skipped", codeLocationA)
+			failure, state := failer.Drain(types.SpecComponentTypeIt, 3, codeLocationB)
+			Ω(failure).Should(Equal(types.SpecFailure{
+				Message:               "something skipped",
+				Location:              codeLocationA,
+				ForwardedPanic:        "",
+				ComponentType:         types.SpecComponentTypeIt,
+				ComponentIndex:        3,
+				ComponentCodeLocation: codeLocationB,
+			}))
+			Ω(state).Should(Equal(types.SpecStateSkipped))
+		})
+	})
+
 	Describe("Fail", func() {
 		It("should handle failures", func() {
 			failer.Fail("something failed", codeLocationA)

--- a/internal/remote/aggregator.go
+++ b/internal/remote/aggregator.go
@@ -209,7 +209,7 @@ func (aggregator *Aggregator) announceSpec(specSummary *types.SpecSummary) {
 	case types.SpecStatePending:
 		aggregator.stenographer.AnnouncePendingSpec(specSummary, aggregator.config.NoisyPendings && !aggregator.config.Succinct)
 	case types.SpecStateSkipped:
-		aggregator.stenographer.AnnounceSkippedSpec(specSummary)
+		aggregator.stenographer.AnnounceSkippedSpec(specSummary, aggregator.config.Succinct && !aggregator.config.NoisySkippings, aggregator.config.FullTrace)
 	case types.SpecStateTimedOut:
 		aggregator.stenographer.AnnounceSpecTimedOut(specSummary, aggregator.config.Succinct, aggregator.config.FullTrace)
 	case types.SpecStatePanicked:

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -65,7 +65,7 @@ func (reporter *DefaultReporter) SpecDidComplete(specSummary *types.SpecSummary)
 	case types.SpecStatePending:
 		reporter.stenographer.AnnouncePendingSpec(specSummary, reporter.config.NoisyPendings && !reporter.config.Succinct)
 	case types.SpecStateSkipped:
-		reporter.stenographer.AnnounceSkippedSpec(specSummary)
+		reporter.stenographer.AnnounceSkippedSpec(specSummary, reporter.config.Succinct && !reporter.config.NoisySkippings, reporter.config.FullTrace)
 	case types.SpecStateTimedOut:
 		reporter.stenographer.AnnounceSpecTimedOut(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
 	case types.SpecStatePanicked:

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -27,7 +27,8 @@ var _ = Describe("DefaultReporter", func() {
 		reporterConfig = config.DefaultReporterConfigType{
 			NoColor:           false,
 			SlowSpecThreshold: 0.1,
-			NoisyPendings:     true,
+			NoisyPendings:     false,
+			NoisySkippings:    false,
 			Verbose:           true,
 			FullTrace:         true,
 		}
@@ -249,8 +250,8 @@ var _ = Describe("DefaultReporter", func() {
 				spec.State = types.SpecStatePending
 			})
 
-			It("should announce the pending spec", func() {
-				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnouncePendingSpec", spec, true)))
+			It("should announce the pending spec, succinctly", func() {
+				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnouncePendingSpec", spec, false)))
 			})
 		})
 
@@ -260,7 +261,7 @@ var _ = Describe("DefaultReporter", func() {
 			})
 
 			It("should announce the skipped spec", func() {
-				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec)))
+				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec, false, true)))
 			})
 		})
 
@@ -291,6 +292,42 @@ var _ = Describe("DefaultReporter", func() {
 
 			It("should announce the failed spec", func() {
 				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSpecFailed", spec, false, true)))
+			})
+		})
+
+		Context("in noisy pendings mode", func() {
+			BeforeEach(func() {
+				reporterConfig.Succinct = false
+				reporterConfig.NoisyPendings = true
+				reporter = reporters.NewDefaultReporter(reporterConfig, stenographer)
+			})
+
+			Context("When the spec is pending", func() {
+				BeforeEach(func() {
+					spec.State = types.SpecStatePending
+				})
+
+				It("should announce the pending spec, noisily", func() {
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnouncePendingSpec", spec, true)))
+				})
+			})
+		})
+
+		Context("in noisy skippings mode", func() {
+			BeforeEach(func() {
+				reporterConfig.Succinct = false
+				reporterConfig.NoisySkippings = true
+				reporter = reporters.NewDefaultReporter(reporterConfig, stenographer)
+			})
+
+			Context("When the spec is skipped", func() {
+				BeforeEach(func() {
+					spec.State = types.SpecStateSkipped
+				})
+
+				It("should announce the skipped spec, noisily", func() {
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec, false, true)))
+				})
 			})
 		})
 
@@ -337,7 +374,7 @@ var _ = Describe("DefaultReporter", func() {
 					spec.State = types.SpecStatePending
 				})
 
-				It("should announce the pending spec, but never noisily", func() {
+				It("should announce the pending spec, succinctly", func() {
 					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnouncePendingSpec", spec, false)))
 				})
 			})
@@ -348,7 +385,7 @@ var _ = Describe("DefaultReporter", func() {
 				})
 
 				It("should announce the skipped spec", func() {
-					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec)))
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec, true, true)))
 				})
 			})
 

--- a/reporters/stenographer/fake_stenographer.go
+++ b/reporters/stenographer/fake_stenographer.go
@@ -117,8 +117,8 @@ func (stenographer *FakeStenographer) AnnouncePendingSpec(spec *types.SpecSummar
 	stenographer.registerCall("AnnouncePendingSpec", spec, noisy)
 }
 
-func (stenographer *FakeStenographer) AnnounceSkippedSpec(spec *types.SpecSummary) {
-	stenographer.registerCall("AnnounceSkippedSpec", spec)
+func (stenographer *FakeStenographer) AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSkippedSpec", spec, succinct, fullTrace)
 }
 
 func (stenographer *FakeStenographer) AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool) {


### PR DESCRIPTION
Example Usage:

```
It("handles skips", func() {
	Skip("show this message and location to the user")
	println("NEVER SEE THIS")
})
```

Implements feature request: #168