### PR TITLE
TestRunner copies compiled file if moving it fails.

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -110,7 +110,9 @@ func (t *TestRunner) CompileTo(path string) error {
 				// We cannot move the file, perhaps because the source and destination
 				// are on different partitions. We can copy the file, however.
 				err = copyFile(compiledFile, path)
-				return fmt.Errorf("Failed to copy compiled file: %s", err)
+				if err != nil {
+					return fmt.Errorf("Failed to copy compiled file: %s", err)
+				}
 			}
 		} else {
 			return fmt.Errorf("Failed to compile %s: output file %q could not be found", t.Suite.PackageName, path)

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -101,13 +101,16 @@ func (t *TestRunner) CompileTo(path string) error {
 	}
 
 	if fileExists(path) == false {
-		compiledFile := filepath.Join(t.Suite.Path, t.Suite. PackageName+".test")
+		compiledFile := filepath.Join(t.Suite.Path, t.Suite.PackageName+".test")
 		if fileExists(compiledFile) {
 			// seems like we are on an old go version that does not support the -o flag on go test
 			// move the compiled test file to the desired location by hand
 			err = os.Rename(compiledFile, path)
 			if err != nil {
-				return fmt.Errorf("Failed to move compiled file: %s", err)
+				// We cannot move the file, perhaps because the source and destination
+				// are on different partitions. We can copy the file, however.
+				err = copyFile(compiledFile, path)
+				return fmt.Errorf("Failed to copy compiled file: %s", err)
 			}
 		} else {
 			return fmt.Errorf("Failed to compile %s: output file %q could not be found", t.Suite.PackageName, path)
@@ -122,6 +125,39 @@ func (t *TestRunner) CompileTo(path string) error {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil || os.IsNotExist(err) == false
+}
+
+// copyFile copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		closeErr := out.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+
+	err = out.Sync()
+	return err
 }
 
 /*


### PR DESCRIPTION
- This fixes an edge case when running on go < 1.4 and moving the file fails,
  perhaps because the source and destination are on different partitions.
- Fixes #189