### PR TITLE
Generate should use the same package as the target file

### DIFF
--- a/ginkgo/generate_command.go
+++ b/ginkgo/generate_command.go
@@ -30,7 +30,7 @@ func BuildGenerateCommand() *Command {
 	}
 }
 
-var specText = `package {{.Package}}_test
+var specText = `package {{.Package}}
 
 import (
 	. "{{.PackageImportPath}}"


### PR DESCRIPTION
Otherwise it leads to the practice of exporting more types in your package than necessary