### PR TITLE
Add linux_arm64 support

### DIFF
--- a/internal/remote/output_interceptor_unix.go
+++ b/internal/remote/output_interceptor_unix.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"syscall"
 )
 
 func NewOutputInterceptor() OutputInterceptor {
@@ -31,8 +30,12 @@ func (interceptor *outputInterceptor) StartInterceptingOutput() error {
 		return err
 	}
 
-	syscall.Dup2(int(interceptor.redirectFile.Fd()), 1)
-	syscall.Dup2(int(interceptor.redirectFile.Fd()), 2)
+	// Call a function in ./syscall_dup_*.go
+	// If building for everything other than linux_arm64,
+	// use a "normal" syscall.Dup2(oldfd, newfd) call. If building for linux_arm64 (which doesn't have syscall.Dup2)
+	// call syscall.Dup3(oldfd, newfd, 0). They are nearly identical, see: http://linux.die.net/man/2/dup3
+	syscallDup(int(interceptor.redirectFile.Fd()), 1)
+	syscallDup(int(interceptor.redirectFile.Fd()), 2)
 
 	return nil
 }

--- a/internal/remote/syscall_dup_linux_arm64.go
+++ b/internal/remote/syscall_dup_linux_arm64.go
@@ -1,0 +1,11 @@
+// +build linux,arm64
+
+package remote
+
+import "syscall"
+
+// linux_arm64 doesn't have syscall.Dup2 which ginkgo uses, so
+// use the nearly identical syscall.Dup3 instead
+func syscallDup(oldfd int, newfd int) (err error) {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/internal/remote/syscall_dup_unix.go
+++ b/internal/remote/syscall_dup_unix.go
@@ -1,0 +1,10 @@
+// +build !linux !arm64
+// +build !windows
+
+package remote
+
+import "syscall"
+
+func syscallDup(oldfd int, newfd int) (err error) {
+	return syscall.Dup2(oldfd, newfd)
+}


### PR DESCRIPTION
Ref: #208

This patch adds support for `linux_arm64` support. 
I'm working on Kubernetes support for `arm64` and Kubernetes uses this project, so if we could merge this it would be great!

The difference between `Dup2` and `Dup3` is here: http://linux.die.net/man/2/dup3
Quick compilation test:
```
$ GOARCH=arm64 GOOS=darwin go build github.com/onsi/ginkgo
$ GOARCH=arm GOOS=darwin go build github.com/onsi/ginkgo
$ GOARCH=amd64 GOOS=darwin go build github.com/onsi/ginkgo
$ GOARCH=amd64 GOOS=netbsd go build github.com/onsi/ginkgo
$ GOARCH=amd64 GOOS=linux go build github.com/onsi/ginkgo
$ GOARCH=arm64 GOOS=linux go build github.com/onsi/ginkgo
$ GOARCH=arm GOOS=linux go build github.com/onsi/ginkgo
```
Build completed successfully on all tests. Earlier `GOARCH=arm64 GOOS=linux` failed.
But I haven't tested it on `arm64` (as I don't have a board yet), but I think it should be OK
Please say what you think!