### PR TITLE
We no longer pass untyped nils to the reflect::Value.Call

### DIFF
--- a/extensions/table/table_entry.go
+++ b/extensions/table/table_entry.go
@@ -23,8 +23,17 @@ func (t TableEntry) generateIt(itBody reflect.Value) {
 	}
 
 	values := []reflect.Value{}
-	for _, param := range t.Parameters {
-		values = append(values, reflect.ValueOf(param))
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
 	}
 
 	body := func() {

--- a/extensions/table/table_test.go
+++ b/extensions/table/table_test.go
@@ -54,4 +54,11 @@ var _ = Describe("Table", func() {
 		Entry("when false", false),
 		Entry("when malformed", 2),
 	)
+
+	DescribeTable("an untyped nil as an entry",
+		func(x interface{}) {
+			Expect(x).To(BeNil())
+		},
+		Entry("nil", nil),
+	)
 })


### PR DESCRIPTION
This would cause panics

Signed-off-by: Topher Bullock <cbullock@pivotal.io>