### PR TITLE
Specify block additions to DSL

### DIFF
--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -347,6 +347,28 @@ func XIt(text string, _ ...interface{}) bool {
 	return true
 }
 
+//Specify blocks are aliases for It blocks and allow for more natural wording in situations
+//which "It" does not fit into a natural sentence flow. All the same protocols apply for Specify blocks
+//which apply to It blocks.
+func Specify(text string, body interface{}, timeout ...float64) bool {
+	return It(text, body, timeout...)
+}
+
+//You can focus individual Specifys using FSpecify
+func FSpecify(text string, body interface{}, timeout ...float64) bool {
+	return FIt(text, body, timeout...)
+}
+
+//You can mark Specifys as pending using PSpecify
+func PSpecify(text string, is ...interface{}) bool {
+	return PIt(text, is...)
+}
+
+//You can mark Specifys as pending using XSpecify
+func XSpecify(text string, is ...interface{}) bool {
+	return XIt(text, is...)
+}
+
 //By allows you to better document large Its.
 //
 //Generally you should try to keep your Its short and to the point.  This is not always possible, however,


### PR DESCRIPTION
In certain cases, `It` does not fit in a natural sentence flow with the surrounding blocks. In these cases, `Specify` would be more natural to read. An example of such blocks would be:

```go
Describe("The foobar service", func() {
  Context("when calling Foo()", func() {
    Context("when no ID is provided", func() {
      Specify("an ErrNoID error is returned", func() {
      })
    })
  })
})
```

The new functions `Specify`, `FSpecify`, `PSpecify`, and `XSpecify` simply pass their arguments to the corresponding `It`, `FIt`, `PIt`, or 'XIt` functions.

I have taken a look around ginkgo's internal test specs and I'm not sure where unit tests would go for these additions, but if someone would like to point me in the right direction I'd be happy to add those and update the pull request.