### PR TITLE
Fixed documentation example

### DIFF
--- a/index.md
+++ b/index.md
@@ -1195,19 +1195,18 @@ To understand this pattern, let's just redo the above example with this pattern:
         })
 
         Describe("failure modes", func() {
+            AssertNoJSONInResponse := func() func() {
+                return func() {
+                    Ω((<-response).JSON).Should(BeZero())
+                }
+            }
+
+            AssertDoesNotReportSuccess := func() func() {
+                return func() {
+                    Ω((<-response).Success).Should(BeFalse())
+                }
+            }
             Context("when the server does not return a 200", func() {
-                AssertNoJSONInResponese := func() func() {
-                    return func() {
-                        Ω((<-response).JSON).Should(BeZero())
-                    }
-                }
-
-                AssertDoesNotReportSuccess := func() func() {
-                    return func() {
-                        Ω((<-response).Success).Should(BeFalse())
-                    }
-                }
-
                 BeforeEach(func() {
                     fakeServer.Respond(404)
                 })


### PR DESCRIPTION
* Currently the code snippet for "Locally-scoped Shared Behaviors" Pattern 2, looks incorrect, as the `AssertNoJSONInResponse` method wont be referable within `Context("when the server returns unparseable JSON"`, fixes that
* Fixes typo `AssertNoJSONInResponse`
