### PR TITLE
Add ability to dump GinkgoWriter on the fly with SIGUSR1

### DIFF
--- a/internal/specrunner/spec_runner.go
+++ b/internal/specrunner/spec_runner.go
@@ -54,6 +54,7 @@ func (runner *SpecRunner) Run() bool {
 
 	runner.reportSuiteWillBegin()
 	go runner.registerForInterrupts()
+	go runner.registerForVerboseSignal()
 
 	suitePassed := runner.runBeforeSuite()
 
@@ -190,6 +191,18 @@ Received interrupt.  Running AfterSuite...
 	}
 	runner.reportSuiteDidEnd(false)
 	os.Exit(1)
+}
+
+func (runner *SpecRunner) registerForVerboseSignal() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGUSR1)
+
+	<-c
+	signal.Stop(c)
+	runner.writer.DumpOutWithHeader(`
+Received SIGUSR1.  Emitting contents of GinkgoWriter...
+---------------------------------------------------------
+`)
 }
 
 func (runner *SpecRunner) registerForHardInterrupts() {


### PR DESCRIPTION
Hey @onsi! 

This is a feature addition to make it so users can signal the Gingko process with SIGUSR1 to flush all the logs the GinkgoWriter has buffered so far. This is useful in the case where you have a test taking longer than expected but don't want to interrupt it, just want to inspect it.

The one open question I have is whether it should flip the bit to switch the GinkgoWriter into verbose/stream mode. Right now it's just flushing and leaving that alone, but I could see the other being useful and maybe even expected.

Thoughts?

Also did a bunch of copy/paste to cobble this together, so feel free to complain wildly about that and maybe I can clean things up.