### PR TITLE
Fix supported Go versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.3
   - 1.4
   - 1.5
+  - 1.6
   - tip
 
 install:


### PR DESCRIPTION
Go 1.3 is no longer supported by Ginkgo. This makes the badge green again. :green_heart: