### PR TITLE
Fixed spelling error in help command instructions

### DIFF
--- a/ginkgo/help_command.go
+++ b/ginkgo/help_command.go
@@ -9,7 +9,7 @@ func BuildHelpCommand() *Command {
 	return &Command{
 		Name:         "help",
 		FlagSet:      flag.NewFlagSet("help", flag.ExitOnError),
-		UsageCommand: "ginkgo help <COMAND>",
+		UsageCommand: "ginkgo help <COMMAND>",
 		Usage: []string{
 			"Print usage information.  If a command is passed in, print usage information just for that command.",
 		},


### PR DESCRIPTION
Silly I know, but it bugged me so I fixed it.