### PR TITLE
fix vendor for 1.6.

### DIFF
--- a/ginkgo/testsuite/test_suite.go
+++ b/ginkgo/testsuite/test_suite.go
@@ -52,8 +52,10 @@ func SuitesInDir(dir string, recurse bool) []TestSuite {
 	// "This change will only be enabled if the go command is run with
 	// GO15VENDOREXPERIMENT=1 in its environment."
 	// c.f. the vendor-experiment proposal https://goo.gl/2ucMeC
+	// in 1.6 the vendor directory became the default go behaviour, so now
+	// check if its disabled.
 	vendorExperiment := os.Getenv("GO15VENDOREXPERIMENT")
-	if (vendorExperiment == "1") && path.Base(dir) == "vendor" {
+	if (vendorExperiment != "0") && path.Base(dir) == "vendor" {
 		return suites
 	}
 


### PR DESCRIPTION
possible fix for #249.

this should still work for <1.5 when it set to 0 or 1, but when it is unset it would skip the vendor directory.

we could also check the go version command output but I'm not sure of every previous versions output I think this is easier.