### PR TITLE
Make JUnit reporter include failure location in message.

### DIFF
--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -74,6 +74,10 @@ func (reporter *JUnitReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary
 	reporter.handleSetupSummary("AfterSuite", setupSummary)
 }
 
+func failureMessage(failure types.SpecFailure) string {
+	return fmt.Sprintf("%s\n%s\n%s", failure.ComponentCodeLocation.String(), failure.Message, failure.Location.String())
+}
+
 func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
 	if setupSummary.State != types.SpecStatePassed {
 		testCase := JUnitTestCase{
@@ -83,7 +87,7 @@ func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *typ
 
 		testCase.FailureMessage = &JUnitFailureMessage{
 			Type:    reporter.failureTypeForState(setupSummary.State),
-			Message: fmt.Sprintf("%s\n%s", setupSummary.Failure.ComponentCodeLocation.String(), setupSummary.Failure.Message),
+			Message: failureMessage(setupSummary.Failure),
 		}
 		testCase.Time = setupSummary.RunTime.Seconds()
 		reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
@@ -98,7 +102,7 @@ func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
 		testCase.FailureMessage = &JUnitFailureMessage{
 			Type:    reporter.failureTypeForState(specSummary.State),
-			Message: fmt.Sprintf("%s\n%s", specSummary.Failure.ComponentCodeLocation.String(), specSummary.Failure.Message),
+			Message: failureMessage(specSummary.Failure),
 		}
 	}
 	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {

--- a/reporters/junit_reporter_test.go
+++ b/reporters/junit_reporter_test.go
@@ -98,6 +98,7 @@ var _ = Describe("JUnit Reporter", func() {
 				Failure: types.SpecFailure{
 					Message:               "failed to setup",
 					ComponentCodeLocation: codelocation.New(0),
+					Location:              codelocation.New(2),
 				},
 			}
 			reporter.BeforeSuiteDidRun(beforeSuite)
@@ -120,6 +121,7 @@ var _ = Describe("JUnit Reporter", func() {
 			Ω(output.TestCases[0].FailureMessage.Type).Should(Equal("Failure"))
 			Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring("failed to setup"))
 			Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring(beforeSuite.Failure.ComponentCodeLocation.String()))
+			Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring(beforeSuite.Failure.Location.String()))
 			Ω(output.TestCases[0].Skipped).Should(BeNil())
 		})
 	})
@@ -134,6 +136,7 @@ var _ = Describe("JUnit Reporter", func() {
 				Failure: types.SpecFailure{
 					Message:               "failed to setup",
 					ComponentCodeLocation: codelocation.New(0),
+					Location:              codelocation.New(2),
 				},
 			}
 			reporter.AfterSuiteDidRun(afterSuite)
@@ -156,6 +159,7 @@ var _ = Describe("JUnit Reporter", func() {
 			Ω(output.TestCases[0].FailureMessage.Type).Should(Equal("Failure"))
 			Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring("failed to setup"))
 			Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring(afterSuite.Failure.ComponentCodeLocation.String()))
+			Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring(afterSuite.Failure.Location.String()))
 			Ω(output.TestCases[0].Skipped).Should(BeNil())
 		})
 	})
@@ -180,6 +184,7 @@ var _ = Describe("JUnit Reporter", func() {
 					RunTime:        5 * time.Second,
 					Failure: types.SpecFailure{
 						ComponentCodeLocation: codelocation.New(0),
+						Location:              codelocation.New(2),
 						Message:               "I failed",
 					},
 				}
@@ -203,6 +208,7 @@ var _ = Describe("JUnit Reporter", func() {
 				Ω(output.TestCases[0].FailureMessage.Type).Should(Equal(specStateCase.message))
 				Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring("I failed"))
 				Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring(spec.Failure.ComponentCodeLocation.String()))
+				Ω(output.TestCases[0].FailureMessage.Message).Should(ContainSubstring(spec.Failure.Location.String()))
 				Ω(output.TestCases[0].Skipped).Should(BeNil())
 			})
 		})


### PR DESCRIPTION
This closely matches the text report output, and provides the line
number of a failing assertion directly-- particularly useful for error
messages like "Expected <bool>: false to equal <bool>: true".