### PR TITLE
Use the go1.5 build tag to handle vendor exceptions

### DIFF
--- a/ginkgo/testsuite/testsuite_test.go
+++ b/ginkgo/testsuite/testsuite_test.go
@@ -1,4 +1,4 @@
-// +build go1.6
+// +build !go1.5
 
 package testsuite_test
 

--- a/ginkgo/testsuite/vendor_check.go
+++ b/ginkgo/testsuite/vendor_check.go
@@ -1,4 +1,4 @@
-// +build go1.6
+// +build !go1.5
 
 package testsuite
 
@@ -7,7 +7,7 @@ import (
 	"path"
 )
 
-// in 1.6 the vendor directory became the default go behaviour, so now
+// in 1.6+ the vendor directory became the default go behaviour, so now
 // check if its disabled.
 func vendorExperimentCheck(dir string) bool {
 	vendorExperiment := os.Getenv("GO15VENDOREXPERIMENT")

--- a/ginkgo/testsuite/vendor_check_go15.go
+++ b/ginkgo/testsuite/vendor_check_go15.go
@@ -1,4 +1,4 @@
-// +build !go1.6
+// +build go1.5
 
 package testsuite
 

--- a/ginkgo/testsuite/vendor_check_go15_test.go
+++ b/ginkgo/testsuite/vendor_check_go15_test.go
@@ -1,4 +1,4 @@
-// +build !go1.6
+// +build go1.5
 
 package testsuite_test
 


### PR DESCRIPTION
In this case Go 1.5 is the exception, and not the rule, so we should use
its build tag to determine the behavior. Otherwise, we will have to
extend the +build line to include all new Go releases in the future.

Related to #249 and #253.