### PR TITLE
Revert "Use the go1.5 build tag to handle vendor exceptions"

### DIFF
--- a/ginkgo/testsuite/testsuite_test.go
+++ b/ginkgo/testsuite/testsuite_test.go
@@ -1,4 +1,4 @@
-// +build !go1.5
+// +build go1.6
 
 package testsuite_test
 

--- a/ginkgo/testsuite/vendor_check_go15.go
+++ b/ginkgo/testsuite/vendor_check_go15.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build !go1.6
 
 package testsuite
 

--- a/ginkgo/testsuite/vendor_check_go15_test.go
+++ b/ginkgo/testsuite/vendor_check_go15_test.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build !go1.6
 
 package testsuite_test
 

--- a/ginkgo/testsuite/vendor_check_go16.go
+++ b/ginkgo/testsuite/vendor_check_go16.go
@@ -1,4 +1,4 @@
-// +build !go1.5
+// +build go1.6
 
 package testsuite
 
@@ -7,7 +7,7 @@ import (
 	"path"
 )
 
-// in 1.6+ the vendor directory became the default go behaviour, so now
+// in 1.6 the vendor directory became the default go behaviour, so now
 // check if its disabled.
 func vendorExperimentCheck(dir string) bool {
 	vendorExperiment := os.Getenv("GO15VENDOREXPERIMENT")


### PR DESCRIPTION
Reverts onsi/ginkgo#272