### PR TITLE
Covermode flag (and reworked pass-through flags passing)

### DIFF
--- a/ginkgo/build_command.go
+++ b/ginkgo/build_command.go
@@ -46,7 +46,7 @@ func (r *SpecBuilder) BuildSpecs(args []string, additionalArgs []string) {
 
 	passed := true
 	for _, suite := range suites {
-		runner := testrunner.New(suite, 1, false, r.commandFlags.Race, r.commandFlags.Cover, r.commandFlags.CoverPkg, r.commandFlags.Tags, r.commandFlags.GCFlags, nil)
+		runner := testrunner.New(suite, 1, false, r.commandFlags.GoFlags, r.commandFlags.GoOpts, nil)
 		fmt.Printf("Compiling %s...\n", suite.PackageName)
 
 		path, _ := filepath.Abs(filepath.Join(suite.Path, fmt.Sprintf("%s.test", suite.PackageName)))

--- a/ginkgo/run_command.go
+++ b/ginkgo/run_command.go
@@ -71,7 +71,7 @@ func (r *SpecRunner) RunSpecs(args []string, additionalArgs []string) {
 
 	runners := []*testrunner.TestRunner{}
 	for _, suite := range suites {
-		runners = append(runners, testrunner.New(suite, r.commandFlags.NumCPU, r.commandFlags.ParallelStream, r.commandFlags.Race, r.commandFlags.Cover, r.commandFlags.CoverPkg, r.commandFlags.Tags, r.commandFlags.GCFlags, additionalArgs))
+		runners = append(runners, testrunner.New(suite, r.commandFlags.NumCPU, r.commandFlags.ParallelStream, r.commandFlags.GoFlags, r.commandFlags.GoOpts, additionalArgs))
 	}
 
 	numSuites := 0

--- a/ginkgo/run_watch_and_build_command_flags.go
+++ b/ginkgo/run_watch_and_build_command_flags.go
@@ -9,12 +9,9 @@ import (
 
 type RunWatchAndBuildCommandFlags struct {
 	Recurse     bool
-	Race        bool
-	Cover       bool
-	CoverPkg    string
 	SkipPackage string
-	Tags        string
-	GCFlags     string
+	GoFlags     map[string]*bool
+	GoOpts      map[string]*string
 
 	//for run and watch commands
 	NumCPU         int
@@ -88,16 +85,31 @@ func (c *RunWatchAndBuildCommandFlags) computeNodes() {
 	}
 }
 
+func (c *RunWatchAndBuildCommandFlags) flagSlot(slot string) *bool {
+	var flag bool
+	c.GoFlags[slot] = &flag
+	return &flag
+}
+
+func (c *RunWatchAndBuildCommandFlags) optSlot(slot string) *string {
+	var opt string
+	c.GoOpts[slot] = &opt
+	return &opt
+}
+
 func (c *RunWatchAndBuildCommandFlags) flags(mode int) {
+	c.GoFlags = make(map[string]*bool)
+	c.GoOpts = make(map[string]*string)
+
 	onWindows := (runtime.GOOS == "windows")
 
 	c.FlagSet.BoolVar(&(c.Recurse), "r", false, "Find and run test suites under the current directory recursively")
-	c.FlagSet.BoolVar(&(c.Race), "race", false, "Run tests with race detection enabled")
-	c.FlagSet.BoolVar(&(c.Cover), "cover", false, "Run tests with coverage analysis, will generate coverage profiles with the package name in the current directory")
-	c.FlagSet.StringVar(&(c.CoverPkg), "coverpkg", "", "Run tests with coverage on the given external modules")
+	c.FlagSet.BoolVar(c.flagSlot("race"), "race", false, "Run tests with race detection enabled")
+	c.FlagSet.BoolVar(c.flagSlot("cover"), "cover", false, "Run tests with coverage analysis, will generate coverage profiles with the package name in the current directory")
+	c.FlagSet.StringVar(c.optSlot("coverPkg"), "coverpkg", "", "Run tests with coverage on the given external modules")
 	c.FlagSet.StringVar(&(c.SkipPackage), "skipPackage", "", "A comma-separated list of package names to be skipped.  If any part of the package's path matches, that package is ignored.")
-	c.FlagSet.StringVar(&(c.Tags), "tags", "", "A list of build tags to consider satisfied during the build")
-	c.FlagSet.StringVar(&(c.GCFlags), "gcflags", "", "Arguments to pass on each go tool compile invocation.")
+	c.FlagSet.StringVar(c.optSlot("tags"), "tags", "", "A list of build tags to consider satisfied during the build")
+	c.FlagSet.StringVar(c.optSlot("gcFlags"), "gcflags", "", "Arguments to pass on each go tool compile invocation.")
 
 	if mode == runMode || mode == watchMode {
 		config.Flags(c.FlagSet, "", false)

--- a/ginkgo/run_watch_and_build_command_flags.go
+++ b/ginkgo/run_watch_and_build_command_flags.go
@@ -110,6 +110,7 @@ func (c *RunWatchAndBuildCommandFlags) flags(mode int) {
 	c.FlagSet.StringVar(&(c.SkipPackage), "skipPackage", "", "A comma-separated list of package names to be skipped.  If any part of the package's path matches, that package is ignored.")
 	c.FlagSet.StringVar(c.optSlot("tags"), "tags", "", "A list of build tags to consider satisfied during the build")
 	c.FlagSet.StringVar(c.optSlot("gcFlags"), "gcflags", "", "Arguments to pass on each go tool compile invocation.")
+	c.FlagSet.StringVar(c.optSlot("covermode"), "covermode", "", "Set the mode for coverage analysis.")
 
 	if mode == runMode || mode == watchMode {
 		config.Flags(c.FlagSet, "", false)

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -73,8 +73,12 @@ func (t *TestRunner) CompileTo(path string) error {
 	if *t.goFlags["race"] {
 		args = append(args, "-race")
 	}
-	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" {
-		args = append(args, "-cover", "-covermode=atomic")
+	if *t.goOpts["covermode"] != "" {
+		args = append(args, "-cover", fmt.Sprintf("-covermode=%s", *t.goOpts["covermode"]))
+	} else {
+		if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" {
+			args = append(args, "-cover", "-covermode=atomic")
+		}
 	}
 	if *t.goOpts["coverPkg"] != "" {
 		args = append(args, fmt.Sprintf("-coverpkg=%s", *t.goOpts["coverPkg"]))
@@ -276,7 +280,7 @@ func (t *TestRunner) runAndStreamParallelGinkgoSuite() RunResult {
 
 	os.Stdout.Sync()
 
-	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" {
+	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" || *t.goOpts["covermode"] != "" {
 		t.combineCoverprofiles()
 	}
 
@@ -358,7 +362,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 		os.Stdout.Sync()
 	}
 
-	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" {
+	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" || *t.goOpts["covermode"] != "" {
 		t.combineCoverprofiles()
 	}
 
@@ -367,7 +371,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 
 func (t *TestRunner) cmd(ginkgoArgs []string, stream io.Writer, node int) *exec.Cmd {
 	args := []string{"--test.timeout=24h"}
-	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" {
+	if *t.goFlags["cover"] || *t.goOpts["coverPkg"] != "" || *t.goOpts["covermode"] != "" {
 		coverprofile := "--test.coverprofile=" + t.Suite.PackageName + ".coverprofile"
 		if t.numCPU > 1 {
 			coverprofile = fmt.Sprintf("%s.%d", coverprofile, node)

--- a/ginkgo/watch_command.go
+++ b/ginkgo/watch_command.go
@@ -57,7 +57,7 @@ func (w *SpecWatcher) runnersForSuites(suites []testsuite.TestSuite, additionalA
 	runners := []*testrunner.TestRunner{}
 
 	for _, suite := range suites {
-		runners = append(runners, testrunner.New(suite, w.commandFlags.NumCPU, w.commandFlags.ParallelStream, w.commandFlags.Race, w.commandFlags.Cover, w.commandFlags.CoverPkg, w.commandFlags.Tags, w.commandFlags.GCFlags, additionalArgs))
+		runners = append(runners, testrunner.New(suite, w.commandFlags.NumCPU, w.commandFlags.ParallelStream, w.commandFlags.GoFlags, w.commandFlags.GoOpts, additionalArgs))
 	}
 
 	return runners

--- a/integration/flags_test.go
+++ b/integration/flags_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,5 +213,19 @@ var _ = Describe("Flags Specs", func() {
 		Eventually(session).Should(gexec.Exit(types.GINKGO_FOCUS_EXIT_CODE))
 		output := string(session.Out.Contents())
 		Ω(output).Should(ContainSubstring("NaN returns complex128"))
+	})
+
+	It("should honor covermode flag", func() {
+		session := startGinkgo(pathToTest, "--noColor", "--covermode=count", "--focus=the focused set")
+		Eventually(session).Should(gexec.Exit(0))
+		output := string(session.Out.Contents())
+		Ω(output).Should(ContainSubstring("coverage: "))
+
+		coverageFile := filepath.Join(pathToTest, "flags.coverprofile")
+		_, err := os.Stat(coverageFile)
+		Ω(err).ShouldNot(HaveOccurred())
+		contents, err := ioutil.ReadFile(coverageFile)
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(contents).Should(ContainSubstring("mode: count"))
 	})
 })


### PR DESCRIPTION
This consolidates Go flags, limiting the number of things passed into the test runner. It also removes the intermediary definitions of the various flags from the `RunWatchAndBuildCommandFlags` and `TestRunner` structs leaving them only in the `flags()` and CompileTo()` functions.

The `covermode` flag is added as a pass-through.