### PR TITLE
Redo flags again, add a bunch of pass-throughs.

### DIFF
--- a/ginkgo/build_command.go
+++ b/ginkgo/build_command.go
@@ -46,7 +46,7 @@ func (r *SpecBuilder) BuildSpecs(args []string, additionalArgs []string) {
 
 	passed := true
 	for _, suite := range suites {
-		runner := testrunner.New(suite, 1, false, r.commandFlags.GoFlags, r.commandFlags.GoOpts, nil)
+		runner := testrunner.New(suite, 1, false, r.commandFlags.GoOpts, nil)
 		fmt.Printf("Compiling %s...\n", suite.PackageName)
 
 		path, _ := filepath.Abs(filepath.Join(suite.Path, fmt.Sprintf("%s.test", suite.PackageName)))

--- a/ginkgo/run_command.go
+++ b/ginkgo/run_command.go
@@ -71,7 +71,7 @@ func (r *SpecRunner) RunSpecs(args []string, additionalArgs []string) {
 
 	runners := []*testrunner.TestRunner{}
 	for _, suite := range suites {
-		runners = append(runners, testrunner.New(suite, r.commandFlags.NumCPU, r.commandFlags.ParallelStream, r.commandFlags.GoFlags, r.commandFlags.GoOpts, additionalArgs))
+		runners = append(runners, testrunner.New(suite, r.commandFlags.NumCPU, r.commandFlags.ParallelStream, r.commandFlags.GoOpts, additionalArgs))
 	}
 
 	numSuites := 0

--- a/ginkgo/run_watch_and_build_command_flags.go
+++ b/ginkgo/run_watch_and_build_command_flags.go
@@ -110,7 +110,7 @@ func (c *RunWatchAndBuildCommandFlags) flags(mode int) {
 	c.FlagSet.BoolVar(&(c.Recurse), "r", false, "Find and run test suites under the current directory recursively.")
 	c.FlagSet.BoolVar(c.boolSlot("race"), "race", false, "Run tests with race detection enabled.")
 	c.FlagSet.BoolVar(c.boolSlot("cover"), "cover", false, "Run tests with coverage analysis, will generate coverage profiles with the package name in the current directory.")
-	c.FlagSet.StringVar(c.stringSlot("coverPkg"), "coverpkg", "", "Run tests with coverage on the given external modules.")
+	c.FlagSet.StringVar(c.stringSlot("coverpkg"), "coverpkg", "", "Run tests with coverage on the given external modules.")
 	c.FlagSet.StringVar(&(c.SkipPackage), "skipPackage", "", "A comma-separated list of package names to be skipped.  If any part of the package's path matches, that package is ignored.")
 	c.FlagSet.StringVar(c.stringSlot("tags"), "tags", "", "A list of build tags to consider satisfied during the build.")
 	c.FlagSet.StringVar(c.stringSlot("gcflags"), "gcflags", "", "Arguments to pass on each go tool compile invocation.")

--- a/ginkgo/run_watch_and_build_command_flags.go
+++ b/ginkgo/run_watch_and_build_command_flags.go
@@ -10,8 +10,7 @@ import (
 type RunWatchAndBuildCommandFlags struct {
 	Recurse     bool
 	SkipPackage string
-	GoFlags     map[string]*bool
-	GoOpts      map[string]*string
+	GoOpts      map[string]interface{}
 
 	//for run and watch commands
 	NumCPU         int
@@ -85,32 +84,57 @@ func (c *RunWatchAndBuildCommandFlags) computeNodes() {
 	}
 }
 
-func (c *RunWatchAndBuildCommandFlags) flagSlot(slot string) *bool {
-	var flag bool
-	c.GoFlags[slot] = &flag
-	return &flag
-}
-
-func (c *RunWatchAndBuildCommandFlags) optSlot(slot string) *string {
+func (c *RunWatchAndBuildCommandFlags) stringSlot(slot string) *string {
 	var opt string
 	c.GoOpts[slot] = &opt
 	return &opt
 }
 
+func (c *RunWatchAndBuildCommandFlags) boolSlot(slot string) *bool {
+	var opt bool
+	c.GoOpts[slot] = &opt
+	return &opt
+}
+
+func (c *RunWatchAndBuildCommandFlags) intSlot(slot string) *int {
+	var opt int
+	c.GoOpts[slot] = &opt
+	return &opt
+}
+
 func (c *RunWatchAndBuildCommandFlags) flags(mode int) {
-	c.GoFlags = make(map[string]*bool)
-	c.GoOpts = make(map[string]*string)
+	c.GoOpts = make(map[string]interface{})
 
 	onWindows := (runtime.GOOS == "windows")
 
-	c.FlagSet.BoolVar(&(c.Recurse), "r", false, "Find and run test suites under the current directory recursively")
-	c.FlagSet.BoolVar(c.flagSlot("race"), "race", false, "Run tests with race detection enabled")
-	c.FlagSet.BoolVar(c.flagSlot("cover"), "cover", false, "Run tests with coverage analysis, will generate coverage profiles with the package name in the current directory")
-	c.FlagSet.StringVar(c.optSlot("coverPkg"), "coverpkg", "", "Run tests with coverage on the given external modules")
+	c.FlagSet.BoolVar(&(c.Recurse), "r", false, "Find and run test suites under the current directory recursively.")
+	c.FlagSet.BoolVar(c.boolSlot("race"), "race", false, "Run tests with race detection enabled.")
+	c.FlagSet.BoolVar(c.boolSlot("cover"), "cover", false, "Run tests with coverage analysis, will generate coverage profiles with the package name in the current directory.")
+	c.FlagSet.StringVar(c.stringSlot("coverPkg"), "coverpkg", "", "Run tests with coverage on the given external modules.")
 	c.FlagSet.StringVar(&(c.SkipPackage), "skipPackage", "", "A comma-separated list of package names to be skipped.  If any part of the package's path matches, that package is ignored.")
-	c.FlagSet.StringVar(c.optSlot("tags"), "tags", "", "A list of build tags to consider satisfied during the build")
-	c.FlagSet.StringVar(c.optSlot("gcFlags"), "gcflags", "", "Arguments to pass on each go tool compile invocation.")
-	c.FlagSet.StringVar(c.optSlot("covermode"), "covermode", "", "Set the mode for coverage analysis.")
+	c.FlagSet.StringVar(c.stringSlot("tags"), "tags", "", "A list of build tags to consider satisfied during the build.")
+	c.FlagSet.StringVar(c.stringSlot("gcflags"), "gcflags", "", "Arguments to pass on each go tool compile invocation.")
+	c.FlagSet.StringVar(c.stringSlot("covermode"), "covermode", "", "Set the mode for coverage analysis.")
+	c.FlagSet.BoolVar(c.boolSlot("a"), "a", false, "Force rebuilding of packages that are already up-to-date.")
+	c.FlagSet.BoolVar(c.boolSlot("n"), "n", false, "Have `go test` print the commands but do not run them.")
+	c.FlagSet.BoolVar(c.boolSlot("msan"), "msan", false, "Enable interoperation with memory sanitizer.")
+	c.FlagSet.BoolVar(c.boolSlot("x"), "x", false, "Have `go test` print the commands.")
+	c.FlagSet.BoolVar(c.boolSlot("work"), "work", false, "Print the name of the temporary work directory and do not delete it when exiting.")
+	c.FlagSet.StringVar(c.stringSlot("asmflags"), "asmflags", "", "Arguments to pass on each go tool asm invocation.")
+	c.FlagSet.StringVar(c.stringSlot("buildmode"), "buildmode", "", "Build mode to use. See 'go help buildmode' for more.")
+	c.FlagSet.StringVar(c.stringSlot("compiler"), "compiler", "", "Name of compiler to use, as in runtime.Compiler (gccgo or gc).")
+	c.FlagSet.StringVar(c.stringSlot("gccgoflags"), "gccgoflags", "", "Arguments to pass on each gccgo compiler/linker invocation.")
+	c.FlagSet.StringVar(c.stringSlot("installsuffix"), "installsuffix", "", "A suffix to use in the name of the package installation directory.")
+	c.FlagSet.StringVar(c.stringSlot("ldflags"), "ldflags", "", "Arguments to pass on each go tool link invocation.")
+	c.FlagSet.BoolVar(c.boolSlot("linkshared"), "linkshared", false, "Link against shared libraries previously created with -buildmode=shared.")
+	c.FlagSet.StringVar(c.stringSlot("pkgdir"), "pkgdir", "", "install and load all packages from the given dir instead of the usual locations.")
+	c.FlagSet.StringVar(c.stringSlot("toolexec"), "toolexec", "", "a program to use to invoke toolchain programs like vet and asm.")
+	c.FlagSet.IntVar(c.intSlot("blockprofilerate"), "blockprofilerate", 1, "Control the detail provided in goroutine blocking profiles by calling runtime.SetBlockProfileRate with the given value.")
+	c.FlagSet.StringVar(c.stringSlot("coverprofile"), "coverprofile", "", "Write a coverage profile to the specified file after all tests have passed.")
+	c.FlagSet.StringVar(c.stringSlot("cpuprofile"), "cpuprofile", "", "Write a CPU profile to the specified file before exiting.")
+	c.FlagSet.StringVar(c.stringSlot("memprofile"), "memprofile", "", "Write a memory profile to the specified file after all tests have passed.")
+	c.FlagSet.IntVar(c.intSlot("memprofilerate"), "memprofilerate", 0, "Enable more precise (and expensive) memory profiles by setting runtime.MemProfileRate.")
+	c.FlagSet.StringVar(c.stringSlot("outputdir"), "outputdir", "", "Place output files from profiling in the specified directory.")
 
 	if mode == runMode || mode == watchMode {
 		config.Flags(c.FlagSet, "", false)

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -63,7 +63,7 @@ func (t *TestRunner) BuildArgs(path string) []string {
 	if *t.goOpts["covermode"].(*string) != "" {
 		args = append(args, "-cover", fmt.Sprintf("-covermode=%s", *t.goOpts["covermode"].(*string)))
 	} else {
-		if *t.goOpts["cover"].(*bool) || *t.goOpts["coverPkg"].(*string) != "" {
+		if *t.goOpts["cover"].(*bool) || *t.goOpts["coverpkg"].(*string) != "" {
 			args = append(args, "-cover", "-covermode=atomic")
 		}
 	}
@@ -108,7 +108,7 @@ func (t *TestRunner) BuildArgs(path string) []string {
 		"cpuprofile",
 		"memprofile",
 		"outputdir",
-		"coverPkg",
+		"coverpkg",
 		"tags",
 		"gcflags",
 	}
@@ -321,7 +321,7 @@ func (t *TestRunner) runAndStreamParallelGinkgoSuite() RunResult {
 
 	os.Stdout.Sync()
 
-	if *t.goOpts["cover"].(*bool) || *t.goOpts["coverPkg"].(*string) != "" || *t.goOpts["covermode"].(*string) != "" {
+	if *t.goOpts["cover"].(*bool) || *t.goOpts["coverpkg"].(*string) != "" || *t.goOpts["covermode"].(*string) != "" {
 		t.combineCoverprofiles()
 	}
 
@@ -403,7 +403,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 		os.Stdout.Sync()
 	}
 
-	if *t.goOpts["cover"].(*bool) || *t.goOpts["coverPkg"].(*string) != "" || *t.goOpts["covermode"].(*string) != "" {
+	if *t.goOpts["cover"].(*bool) || *t.goOpts["coverpkg"].(*string) != "" || *t.goOpts["covermode"].(*string) != "" {
 		t.combineCoverprofiles()
 	}
 
@@ -412,7 +412,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 
 func (t *TestRunner) cmd(ginkgoArgs []string, stream io.Writer, node int) *exec.Cmd {
 	args := []string{"--test.timeout=24h"}
-	if *t.goOpts["cover"].(*bool) || *t.goOpts["coverPkg"].(*string) != "" || *t.goOpts["covermode"].(*string) != "" {
+	if *t.goOpts["cover"].(*bool) || *t.goOpts["coverpkg"].(*string) != "" || *t.goOpts["covermode"].(*string) != "" {
 		coverprofile := "--test.coverprofile=" + t.Suite.PackageName + ".coverprofile"
 		if t.numCPU > 1 {
 			coverprofile = fmt.Sprintf("%s.%d", coverprofile, node)

--- a/ginkgo/testrunner/test_runner_test.go
+++ b/ginkgo/testrunner/test_runner_test.go
@@ -28,7 +28,7 @@ var _ = Describe("TestRunner", func() {
 			"pkgdir":           strAddr("b"),
 			"gcflags":          strAddr("c"),
 			"covermode":        strAddr(""),
-			"coverPkg":         strAddr(""),
+			"coverpkg":         strAddr(""),
 			"cover":            boolAddr(false),
 			"blockprofilerate": intAddr(100),
 		}

--- a/ginkgo/testrunner/test_runner_test.go
+++ b/ginkgo/testrunner/test_runner_test.go
@@ -1,0 +1,56 @@
+package testrunner_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/ginkgo/testrunner"
+	"github.com/onsi/ginkgo/ginkgo/testsuite"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func strAddr(s string) interface{} {
+	return &s
+}
+
+func boolAddr(s bool) interface{} {
+	return &s
+}
+
+func intAddr(s int) interface{} {
+	return &s
+}
+
+var _ = Describe("TestRunner", func() {
+	It("should pass through go opts", func() {
+		//var opts map[string]interface{}
+		opts := map[string]interface{}{
+			"asmflags":         strAddr("a"),
+			"pkgdir":           strAddr("b"),
+			"gcflags":          strAddr("c"),
+			"covermode":        strAddr(""),
+			"coverPkg":         strAddr(""),
+			"cover":            boolAddr(false),
+			"blockprofilerate": intAddr(100),
+		}
+		tr := testrunner.New(testsuite.TestSuite{}, 1, false, opts, []string{})
+
+		args := tr.BuildArgs(".")
+		Ω(args).Should(Equal([]string{
+			"test",
+			"-c",
+			"-i",
+			"-o",
+			".",
+			"",
+			"-blockprofilerate=100",
+			"-asmflags=a",
+			"-pkgdir=b",
+			"-gcflags=c",
+		}))
+	})
+})
+
+func TestTestRunner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Runner Suite")
+}

--- a/ginkgo/watch_command.go
+++ b/ginkgo/watch_command.go
@@ -57,7 +57,7 @@ func (w *SpecWatcher) runnersForSuites(suites []testsuite.TestSuite, additionalA
 	runners := []*testrunner.TestRunner{}
 
 	for _, suite := range suites {
-		runners = append(runners, testrunner.New(suite, w.commandFlags.NumCPU, w.commandFlags.ParallelStream, w.commandFlags.GoFlags, w.commandFlags.GoOpts, additionalArgs))
+		runners = append(runners, testrunner.New(suite, w.commandFlags.NumCPU, w.commandFlags.ParallelStream, w.commandFlags.GoOpts, additionalArgs))
 	}
 
 	return runners


### PR DESCRIPTION
This is a proposal to support a bunch of new flags. It should take care of my issue (I need `coverprofile`) as well as #277. It simplifies things in that it puts all the pass-through options into a single map but makes other things more complex as it's a map of interface values. 

This adds a degenerate test for the new flags but keeps the old flag tests intact.