### PR TITLE
Add package path prefix to compilation output path only if missing

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -229,6 +229,7 @@ fixCompilationOutput..... rewrites the output to fix the paths.
 yeah......
 */
 func fixCompilationOutput(output string, relToPath string) string {
+	relToPath = filepath.Join(relToPath)
 	re := regexp.MustCompile(`^(\S.*\.go)\:\d+\:`)
 	lines := strings.Split(output, "\n")
 	for i, line := range lines {
@@ -238,8 +239,10 @@ func fixCompilationOutput(output string, relToPath string) string {
 		}
 
 		path := line[indices[2]:indices[3]]
-		path = filepath.Join(relToPath, path)
-		lines[i] = path + line[indices[3]:]
+		if filepath.Dir(path) != relToPath {
+			path = filepath.Join(relToPath, path)
+			lines[i] = path + line[indices[3]:]
+		}
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
With the latest version of Ginkgo and a recent version of Go (1.6.3), if tests fail to compile then the error message file paths include the directory path twice. This patch checks to see if the path already includes the directory path and, if so, does not add it a second time. 

Note: I'm not sure what "older versions of Go" do not support the "-o" option and require the function `fixCompilationOutput`, but if those older versions are no longer supported by Ginkgo, then this entire function and its use can probably go away. I'll let you make that call.