### PR TITLE
#287 Ensure Logf/Skipf insert newline characters

### DIFF
--- a/internal/testingtproxy/testing_t_proxy.go
+++ b/internal/testingtproxy/testing_t_proxy.go
@@ -50,7 +50,7 @@ func (t *ginkgoTestingTProxy) Log(args ...interface{}) {
 }
 
 func (t *ginkgoTestingTProxy) Logf(format string, args ...interface{}) {
-	fmt.Fprintf(t.writer, format, args...)
+	t.Log(fmt.Sprintf(format, args...))
 }
 
 func (t *ginkgoTestingTProxy) Failed() bool {
@@ -65,7 +65,7 @@ func (t *ginkgoTestingTProxy) Skip(args ...interface{}) {
 }
 
 func (t *ginkgoTestingTProxy) Skipf(format string, args ...interface{}) {
-	fmt.Printf(format, args...)
+	t.Skip(fmt.Sprintf(format, args...))
 }
 
 func (t *ginkgoTestingTProxy) SkipNow() {


### PR DESCRIPTION
The standard golang testing.T object methods Logf/Skipf log output with newlines. This change makes the GinkgoT() proxy consistent with this behavior.