### PR TITLE
Include flake count in test summary

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -337,7 +337,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 	writers := make([]*logWriter, t.numCPU)
 	reports := make([]*bytes.Buffer, t.numCPU)
 
-	stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor)
+	stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor, config.GinkgoConfig.FlakeAttempts > 1)
 	aggregator := remote.NewAggregator(t.numCPU, result, config.DefaultReporterConfig, stenographer)
 
 	server, err := remote.NewServer(t.numCPU)

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -218,7 +218,7 @@ func RunSpecsWithCustomReporters(t GinkgoTestingT, description string, specRepor
 func buildDefaultReporter() Reporter {
 	remoteReportingServer := config.GinkgoConfig.StreamHost
 	if remoteReportingServer == "" {
-		stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor)
+		stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor, config.GinkgoConfig.FlakeAttempts > 1)
 		return reporters.NewDefaultReporter(config.DefaultReporterConfig, stenographer)
 	} else {
 		return remote.NewForwardingReporter(remoteReportingServer, &http.Client{}, remote.NewOutputInterceptor())


### PR DESCRIPTION
Previously, flakes could result in confusing messages like:

```
Summarizing 1 Failure:

[Fail] [k8s.io] Pods [It] should contain environment variables for services [Conformance] 
/var/lib/jenkins/workspace/node-pull-build-e2e-test/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:2125

Ran 97 of 129 Specs in 562.705 seconds
SUCCESS! -- 97 Passed | 0 Failed | 0 Pending | 32 Skipped 

Ginkgo ran 1 suite in 9m25.151025459s
Test Suite Passed

Success Finished Test Suite on Host tmp-node-e2e-4e4fc36a-e2e-node-containervm-v20160321-image
```

By including the `| 1 Flaked |` message, it should be slightly less confusing why thatt failure wasn't counted.

Fixes https://github.com/kubernetes/kubernetes/issues/31802

/cc @lavalamp 