### PR TITLE
Expose the random seed via GinkgoRandomSeed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Improvements:
 
 - `Skip(message)` can be used to skip the current test.
 - Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](http://onsi.github.io/ginkgo/#table-driven-tests)
+- Add `GinkgoRandomSeed()` - shorthand for `config.GinkgoConfig.RandomSeed`
 
 Bug Fixes:
 

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -68,6 +68,14 @@ type GinkgoTestingT interface {
 	Fail()
 }
 
+//GinkgoRandomSeed returns the seed used to randomize spec execution order.  It is
+//useful for seeding your own pseudorandom number generators (PRNGs) to ensure
+//consistent executions from run to run, where your tests contain variability (for
+//example, when selecting random test data).
+func GinkgoRandomSeed() int64 {
+	return config.GinkgoConfig.RandomSeed
+}
+
 //GinkgoParallelNode returns the parallel node number for the current ginkgo process
 //The node number is 1-indexed
 func GinkgoParallelNode() int {


### PR DESCRIPTION
This change exposes the random seed used internally by Ginkgo to randomize
spec execution order.  If your own tests make use of randomness, using the
same seed ensures that your test executions are repeatable.  This can be
helpful for tests that randomly generate test data.

Closes: #286