### PR TITLE
Add ability to specify a custom bootstrap file

### DIFF
--- a/ginkgo/bootstrap_command.go
+++ b/ginkgo/bootstrap_command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,11 +16,15 @@ import (
 )
 
 func BuildBootstrapCommand() *Command {
-	var agouti, noDot, internal bool
+	var (
+		agouti, noDot, internal bool
+		customBootstrapFile     string
+	)
 	flagSet := flag.NewFlagSet("bootstrap", flag.ExitOnError)
 	flagSet.BoolVar(&agouti, "agouti", false, "If set, bootstrap will generate a bootstrap file for writing Agouti tests")
 	flagSet.BoolVar(&noDot, "nodot", false, "If set, bootstrap will generate a bootstrap file that does not . import ginkgo and gomega")
 	flagSet.BoolVar(&internal, "internal", false, "If set, generate will generate a test file that uses the regular package name")
+	flagSet.StringVar(&customBootstrapFile, "template", "", "If specified, generate will use the contents of the file passed as the bootstrap template")
 
 	return &Command{
 		Name:         "bootstrap",
@@ -30,7 +35,7 @@ func BuildBootstrapCommand() *Command {
 			"Accepts the following flags:",
 		},
 		Command: func(args []string, additionalArgs []string) {
-			generateBootstrap(agouti, noDot, internal)
+			generateBootstrap(agouti, noDot, internal, customBootstrapFile)
 		},
 	}
 }
@@ -132,7 +137,7 @@ func fileExists(path string) bool {
 	return false
 }
 
-func generateBootstrap(agouti, noDot, internal bool) {
+func generateBootstrap(agouti, noDot, internal bool, customBootstrapFile string) {
 	packageName, bootstrapFilePrefix, formattedName := getPackageAndFormattedName()
 	data := bootstrapData{
 		Package:       determinePackageName(packageName, internal),
@@ -162,7 +167,13 @@ func generateBootstrap(agouti, noDot, internal bool) {
 	defer f.Close()
 
 	var templateText string
-	if agouti {
+	if customBootstrapFile != "" {
+		tpl, err := ioutil.ReadFile(customBootstrapFile)
+		if err != nil {
+			panic(err.Error())
+		}
+		templateText = string(tpl)
+	} else if agouti {
 		templateText = agoutiBootstrapText
 	} else {
 		templateText = bootstrapText

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -85,10 +85,16 @@ var _ = Describe("Subcommand", func() {
 
 		It("should generate a bootstrap file using a template when told to", func() {
 			templateFile := filepath.Join(pkgPath, ".bootstrap")
-			ioutil.WriteFile(templateFile, []byte(`
-			package {{.Package}}
-			Ginkgo: {{.GinkgoImport}}
-			Gomega: {{.GomegaImport}}
+			ioutil.WriteFile(templateFile, []byte(`package {{.Package}}
+
+			import (
+				{{.GinkgoImport}}
+				{{.GomegaImport}}
+
+				"testing"
+				"binary"
+			)
+
 			func Test{{.FormattedName}}(t *testing.T) {
 				// This is a {{.Package}} test
 			}`), 0666)
@@ -101,8 +107,9 @@ var _ = Describe("Subcommand", func() {
 			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("package foo_test"))
-			Ω(content).Should(ContainSubstring(`Ginkgo: . "github.com/onsi/ginkgo"`))
-			Ω(content).Should(ContainSubstring(`Gomega: . "github.com/onsi/gomega"`))
+			Ω(content).Should(ContainSubstring(`. "github.com/onsi/ginkgo"`))
+			Ω(content).Should(ContainSubstring(`. "github.com/onsi/gomega"`))
+			Ω(content).Should(ContainSubstring(`"binary"`))
 			Ω(content).Should(ContainSubstring("// This is a foo_test test"))
 		})
 	})

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -82,6 +82,29 @@ var _ = Describe("Subcommand", func() {
 			Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/gomega"`))
 			Ω(content).Should(ContainSubstring("\t" + `"github.com/sclevine/agouti"`))
 		})
+
+		It("should generate a bootstrap file using a template when told to", func() {
+			templateFile := filepath.Join(pkgPath, ".bootstrap")
+			ioutil.WriteFile(templateFile, []byte(`
+			package {{.Package}}
+			Ginkgo: {{.GinkgoImport}}
+			Gomega: {{.GomegaImport}}
+			func Test{{.FormattedName}}(t *testing.T) {
+				// This is a {{.Package}} test
+			}`), 0666)
+			session := startGinkgo(pkgPath, "bootstrap", "--template", templateFile)
+			Eventually(session).Should(gexec.Exit(0))
+			output := session.Out.Contents()
+
+			Ω(output).Should(ContainSubstring("foo_suite_test.go"))
+
+			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(ContainSubstring("package foo_test"))
+			Ω(content).Should(ContainSubstring(`Ginkgo: . "github.com/onsi/ginkgo"`))
+			Ω(content).Should(ContainSubstring(`Gomega: . "github.com/onsi/gomega"`))
+			Ω(content).Should(ContainSubstring("// This is a foo_test test"))
+		})
 	})
 
 	Describe("nodot", func() {


### PR DESCRIPTION
When setting up a new project that, for example, standardizes on jUnit output, it's useful to provide a different bootstrap file for everyone to use. This PR adds a flag to `ginkgo bootstrap` that lets you pass a filename containing an alternate template.