### PR TITLE
Fix tests for single node machine

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -238,6 +238,9 @@ var _ = Describe("Running Specs", func() {
 				output := string(session.Out.Contents())
 
 				nodes := runtime.NumCPU()
+				if nodes == 1 {
+					Skip("Can't test parallel testings with 1 CPU")
+				}
 				if nodes > 4 {
 					nodes = nodes - 1
 				}


### PR DESCRIPTION
When there is only one node, number of nodes is not shown and test fails.