### PR TITLE
Include captured output from failed tests into JUnit

### DIFF
--- a/internal/specrunner/spec_runner.go
+++ b/internal/specrunner/spec_runner.go
@@ -271,6 +271,9 @@ func (runner *SpecRunner) reportSpecWillRun(summary *types.SpecSummary) {
 }
 
 func (runner *SpecRunner) reportSpecDidComplete(summary *types.SpecSummary, failed bool) {
+	if failed && len(summary.CapturedOutput) == 0 {
+		summary.CapturedOutput = string(runner.writer.Bytes())
+	}
 	for i := len(runner.reporters) - 1; i >= 1; i-- {
 		runner.reporters[i].SpecDidComplete(summary)
 	}

--- a/internal/specrunner/spec_runner_test.go
+++ b/internal/specrunner/spec_runner_test.go
@@ -718,6 +718,7 @@ var _ = Describe("Spec Runner", func() {
 				"R1.WillRun",
 				"R2.WillRun",
 				"B",
+				"BYTES",
 				"R2.DidComplete",
 				"DUMP",
 				"R1.DidComplete",

--- a/internal/writer/fake_writer.go
+++ b/internal/writer/fake_writer.go
@@ -26,6 +26,11 @@ func (writer *FakeGinkgoWriter) DumpOutWithHeader(header string) {
 	writer.EventStream = append(writer.EventStream, "DUMP_WITH_HEADER: "+header)
 }
 
+func (writer *FakeGinkgoWriter) Bytes() []byte {
+	writer.EventStream = append(writer.EventStream, "BYTES")
+	return nil
+}
+
 func (writer *FakeGinkgoWriter) Write(data []byte) (n int, err error) {
 	return 0, nil
 }

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -12,6 +12,7 @@ type WriterInterface interface {
 	Truncate()
 	DumpOut()
 	DumpOutWithHeader(header string)
+	Bytes() []byte
 }
 
 type Writer struct {
@@ -40,11 +41,11 @@ func (w *Writer) Write(b []byte) (n int, err error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
+	n, err = w.buffer.Write(b)
 	if w.stream {
 		return w.outWriter.Write(b)
-	} else {
-		return w.buffer.Write(b)
 	}
+	return n, err
 }
 
 func (w *Writer) Truncate() {
@@ -59,6 +60,15 @@ func (w *Writer) DumpOut() {
 	if !w.stream {
 		w.buffer.WriteTo(w.outWriter)
 	}
+}
+
+func (w *Writer) Bytes() []byte {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	b := w.buffer.Bytes()
+	copied := make([]byte, len(b))
+	copy(copied, b)
+	return copied
 }
 
 func (w *Writer) DumpOutWithHeader(header string) {

--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -31,6 +31,7 @@ type JUnitTestCase struct {
 	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
 	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
 	Time           float64              `xml:"time,attr"`
+	SystemOut      string               `xml:"system-out,omitempty"`
 }
 
 type JUnitFailureMessage struct {
@@ -89,6 +90,7 @@ func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *typ
 			Type:    reporter.failureTypeForState(setupSummary.State),
 			Message: failureMessage(setupSummary.Failure),
 		}
+		testCase.SystemOut = setupSummary.CapturedOutput
 		testCase.Time = setupSummary.RunTime.Seconds()
 		reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
 	}
@@ -104,6 +106,7 @@ func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 			Type:    reporter.failureTypeForState(specSummary.State),
 			Message: failureMessage(specSummary.Failure),
 		}
+		testCase.SystemOut = specSummary.CapturedOutput
 	}
 	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
 		testCase.Skipped = &JUnitSkipped{}


### PR DESCRIPTION
JUnit has the ability to report the full output of a test run via the
system-out field which is not currently exposed. This commit turns the
test Writer in a capturing writer even when streaming so that the JUnit
reporter will have access to CapturedOutput from the Spec. Failed tests
include that output.

For suites that generate a lot of log output, being able to zoom in to a
particular failed test and see the output all at once makes various
JUnit visualization outputs more effective (like in Jenkins).