### PR TITLE
Add the ability to use ./... to recursively test directories

### DIFF
--- a/ginkgo/main.go
+++ b/ginkgo/main.go
@@ -234,7 +234,7 @@ func complainAndQuit(complaint string) {
 	os.Exit(1)
 }
 
-func findSuites(args []string, recurse bool, skipPackage string, allowPrecompiled bool) ([]testsuite.TestSuite, []string) {
+func findSuites(args []string, recurseForAll bool, skipPackage string, allowPrecompiled bool) ([]testsuite.TestSuite, []string) {
 	suites := []testsuite.TestSuite{}
 
 	if len(args) > 0 {
@@ -246,10 +246,15 @@ func findSuites(args []string, recurse bool, skipPackage string, allowPrecompile
 					continue
 				}
 			}
-			suites = append(suites, testsuite.SuitesInDir(arg, recurse)...)
+			recurseForSuite := recurseForAll
+			if strings.HasSuffix(arg, "/...") && arg != "/..." {
+				arg = arg[:len(arg)-4]
+				recurseForSuite = true
+			}
+			suites = append(suites, testsuite.SuitesInDir(arg, recurseForSuite)...)
 		}
 	} else {
-		suites = testsuite.SuitesInDir(".", recurse)
+		suites = testsuite.SuitesInDir(".", recurseForAll)
 	}
 
 	skippedPackages := []string{}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -278,15 +278,29 @@ var _ = Describe("Running Specs", func() {
 		})
 
 		Context("when all the tests pass", func() {
-			It("should run all the tests (in succinct mode) and succeed", func() {
-				session := startGinkgo(tmpDir, "--noColor", "-r")
-				Eventually(session).Should(gexec.Exit(0))
-				output := string(session.Out.Contents())
+			Context("with the -r flag", func() {
+				It("should run all the tests (in succinct mode) and succeed", func() {
+					session := startGinkgo(tmpDir, "--noColor", "-r", ".")
+					Eventually(session).Should(gexec.Exit(0))
+					output := string(session.Out.Contents())
 
-				outputLines := strings.Split(output, "\n")
-				Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs [%s]{4} SUCCESS! \d+(\.\d+)?[muµ]s PASS`, regexp.QuoteMeta(denoter)))
-				Ω(outputLines[1]).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs [%s]{2} SUCCESS! \d+(\.\d+)?[muµ]s PASS`, regexp.QuoteMeta(denoter)))
-				Ω(output).Should(ContainSubstring("Test Suite Passed"))
+					outputLines := strings.Split(output, "\n")
+					Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs [%s]{4} SUCCESS! \d+(\.\d+)?[muµ]s PASS`, regexp.QuoteMeta(denoter)))
+					Ω(outputLines[1]).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs [%s]{2} SUCCESS! \d+(\.\d+)?[muµ]s PASS`, regexp.QuoteMeta(denoter)))
+					Ω(output).Should(ContainSubstring("Test Suite Passed"))
+				})
+			})
+			Context("with a trailing /...", func() {
+				It("should run all the tests (in succinct mode) and succeed", func() {
+					session := startGinkgo(tmpDir, "--noColor", "./...")
+					Eventually(session).Should(gexec.Exit(0))
+					output := string(session.Out.Contents())
+
+					outputLines := strings.Split(output, "\n")
+					Ω(outputLines[0]).Should(MatchRegexp(`\[\d+\] Passing_ginkgo_tests Suite - 4/4 specs [%s]{4} SUCCESS! \d+(\.\d+)?[muµ]s PASS`, regexp.QuoteMeta(denoter)))
+					Ω(outputLines[1]).Should(MatchRegexp(`\[\d+\] More_ginkgo_tests Suite - 2/2 specs [%s]{2} SUCCESS! \d+(\.\d+)?[muµ]s PASS`, regexp.QuoteMeta(denoter)))
+					Ω(output).Should(ContainSubstring("Test Suite Passed"))
+				})
 			})
 		})
 


### PR DESCRIPTION
Existing `go` commands (`go test`, `go install`, `go build`, etc) let the user recurse into subpackages by ending a path, relative or absolute, with `/...`. Thought it would a nice usability enhancement. This also provides the ability to recurse into some directories and not others, which can be useful for finer-grain control when running expensive `ginkgo watch` processes.

e.g.

```
ginkgo watch ./only/this/package ./and/all/...
```