### PR TITLE
Don't colorize output by default if not writing to a TTY

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,11 @@ package config
 
 import (
 	"flag"
-	"time"
-
 	"fmt"
+	"time"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const VERSION = "1.2.0"
@@ -44,12 +46,37 @@ type GinkgoConfigType struct {
 var GinkgoConfig = GinkgoConfigType{}
 
 type DefaultReporterConfigType struct {
-	NoColor           bool
 	SlowSpecThreshold float64
 	NoisyPendings     bool
 	Succinct          bool
 	Verbose           bool
 	FullTrace         bool
+
+	color   bool
+	noColor bool
+
+	// Colorize caches whether or not we want to colorize output
+	Colorize *bool
+}
+
+// ColorizeOutput determines if output should be colorized. The user
+// can specify they want color (--color) or not (--noColor). Further-
+// more, we detect if the output to which we are printing is a TTY.
+// If the output is a TTY, the default is to use color but a user can
+// still request no color; if the output is not a TTY, the default is
+// to not use color but the user can still request it.
+func (c *DefaultReporterConfigType) ColorizeOutput() bool {
+	if c.Colorize == nil {
+		var colorize bool
+		if terminal.IsTerminal(int(os.Stdout.Fd())) {
+			colorize = !c.noColor
+		} else {
+			colorize = c.color
+		}
+		c.Colorize = &colorize
+	}
+
+	return *c.Colorize
 }
 
 var DefaultReporterConfig = DefaultReporterConfigType{}
@@ -87,7 +114,8 @@ func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
 		flagSet.StringVar(&(GinkgoConfig.StreamHost), prefix+"parallel.streamhost", "", "The address for the server that the running nodes should stream data to.")
 	}
 
-	flagSet.BoolVar(&(DefaultReporterConfig.NoColor), prefix+"noColor", false, "If set, suppress color output in default reporter.")
+	flagSet.BoolVar(&(DefaultReporterConfig.color), prefix+"color", false, "If set, enable color output in default reporter even when not printing to a TTY.")
+	flagSet.BoolVar(&(DefaultReporterConfig.noColor), prefix+"noColor", false, "If set, suppress color output in default reporter.")
 	flagSet.Float64Var(&(DefaultReporterConfig.SlowSpecThreshold), prefix+"slowSpecThreshold", 5.0, "(in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter.")
 	flagSet.BoolVar(&(DefaultReporterConfig.NoisyPendings), prefix+"noisyPendings", true, "If set, default reporter will shout about pending tests.")
 	flagSet.BoolVar(&(DefaultReporterConfig.Verbose), prefix+"v", false, "If set, default reporter print out all specs as they begin.")
@@ -159,8 +187,8 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 		result = append(result, fmt.Sprintf("--%sregexScansFilePath", prefix))
 	}
 
-	if reporter.NoColor {
-		result = append(result, fmt.Sprintf("--%snoColor", prefix))
+	if reporter.ColorizeOutput() {
+		result = append(result, fmt.Sprintf("--%scolor", prefix))
 	}
 
 	if reporter.SlowSpecThreshold > 0 {

--- a/ginkgo/notifications.go
+++ b/ginkgo/notifications.go
@@ -123,18 +123,18 @@ func (n *Notifier) RunCommand(suite testsuite.TestSuite, suitePassed bool) {
 		output, err := exec.Command(parts[0], parts[1:]...).CombinedOutput()
 		if err != nil {
 			fmt.Println("Post-suite command failed:")
-			if config.DefaultReporterConfig.NoColor {
-				fmt.Printf("\t%s\n", output)
-			} else {
+			if config.DefaultReporterConfig.ColorizeOutput() {
 				fmt.Printf("\t%s%s%s\n", redColor, string(output), defaultStyle)
+			} else {
+				fmt.Printf("\t%s\n", output)
 			}
 			n.SendNotification("Ginkgo [ERROR]", fmt.Sprintf(`After suite command "%s" failed`, n.commandFlags.AfterSuiteHook))
 		} else {
 			fmt.Println("Post-suite command succeeded:")
-			if config.DefaultReporterConfig.NoColor {
-				fmt.Printf("\t%s\n", output)
-			} else {
+			if config.DefaultReporterConfig.ColorizeOutput() {
 				fmt.Printf("\t%s%s%s\n", greenColor, string(output), defaultStyle)
+			} else {
+				fmt.Printf("\t%s\n", output)
 			}
 		}
 	}

--- a/ginkgo/suite_runner.go
+++ b/ginkgo/suite_runner.go
@@ -164,10 +164,10 @@ func (r *SuiteRunner) listFailedSuites(suitesThatFailed []testsuite.TestSuite) {
 	packageNameFormatter := fmt.Sprintf("%%%ds", maxPackageNameLength)
 
 	for _, suite := range suitesThatFailed {
-		if config.DefaultReporterConfig.NoColor {
-			fmt.Printf("\t"+packageNameFormatter+" %s\n", suite.PackageName, suite.Path)
-		} else {
+		if config.DefaultReporterConfig.ColorizeOutput() {
 			fmt.Fprintf(colorable.NewColorableStdout(), "\t%s"+packageNameFormatter+"%s %s%s%s\n", redColor, suite.PackageName, defaultStyle, lightGrayColor, suite.Path, defaultStyle)
+		} else {
+			fmt.Printf("\t"+packageNameFormatter+" %s\n", suite.PackageName, suite.Path)
 		}
 	}
 }

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -337,7 +337,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 	writers := make([]*logWriter, t.numCPU)
 	reports := make([]*bytes.Buffer, t.numCPU)
 
-	stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor, config.GinkgoConfig.FlakeAttempts > 1)
+	stenographer := stenographer.New(config.DefaultReporterConfig.ColorizeOutput(), config.GinkgoConfig.FlakeAttempts > 1)
 	aggregator := remote.NewAggregator(t.numCPU, result, config.DefaultReporterConfig, stenographer)
 
 	server, err := remote.NewServer(t.numCPU)

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -226,7 +226,7 @@ func RunSpecsWithCustomReporters(t GinkgoTestingT, description string, specRepor
 func buildDefaultReporter() Reporter {
 	remoteReportingServer := config.GinkgoConfig.StreamHost
 	if remoteReportingServer == "" {
-		stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor, config.GinkgoConfig.FlakeAttempts > 1)
+		stenographer := stenographer.New(config.DefaultReporterConfig.ColorizeOutput(), config.GinkgoConfig.FlakeAttempts > 1)
 		return reporters.NewDefaultReporter(config.DefaultReporterConfig, stenographer)
 	} else {
 		return remote.NewForwardingReporter(remoteReportingServer, &http.Client{}, remote.NewOutputInterceptor())
@@ -388,9 +388,9 @@ func XSpecify(text string, is ...interface{}) bool {
 //By allows you to document such flows.  By must be called within a runnable node (It, BeforeEach, Measure, etc...)
 //By will simply log the passed in text to the GinkgoWriter.  If By is handed a function it will immediately run the function.
 func By(text string, callbacks ...func()) {
-	preamble := "\x1b[1mSTEP\x1b[0m"
-	if config.DefaultReporterConfig.NoColor {
-		preamble = "STEP"
+	preamble := "STEP"
+	if config.DefaultReporterConfig.ColorizeOutput() {
+		preamble = "\x1b[1mSTEP\x1b[0m"
 	}
 	fmt.Fprintln(GinkgoWriter, preamble+": "+text)
 	if len(callbacks) == 1 {

--- a/internal/remote/aggregator_test.go
+++ b/internal/remote/aggregator_test.go
@@ -32,8 +32,9 @@ var _ = Describe("Aggregator", func() {
 	)
 
 	BeforeEach(func() {
+		colorize := true
 		reporterConfig = config.DefaultReporterConfigType{
-			NoColor:           false,
+			Colorize:          &colorize,
 			SlowSpecThreshold: 0.1,
 			NoisyPendings:     true,
 			Succinct:          false,

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -24,8 +24,9 @@ var _ = Describe("DefaultReporter", func() {
 
 	BeforeEach(func() {
 		stenographer = st.NewFakeStenographer()
+		colorize := true
 		reporterConfig = config.DefaultReporterConfigType{
-			NoColor:           false,
+			Colorize:          &colorize,
 			SlowSpecThreshold: 0.1,
 			NoisyPendings:     false,
 			Verbose:           true,


### PR DESCRIPTION
The current behavior of `ginkgo` is to write ANSI escape codes to the
output stream to colorize messages by default. This leads to mangled and
unreadable logs unless the user knows to pass `--noColor`. Instead, the
default reporter should check to see if the output file descriptor is a
TTY and colorize output only if it is, or if the user has specifically
provides the `--color` flag.

This patch breaks backward compatibility for users that expected ANSI
escape codes printed to non-TTY file descriptors, but those users can
pass `--color` to return to the previous behavior. All other users
should not notice this change.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/onsi/ginkgo/issues/326#issuecomment-283958838
/cc @smarterclayton 