### PR TITLE
Pass `--noColor` to test binary for compatibility

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,8 +187,8 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 		result = append(result, fmt.Sprintf("--%sregexScansFilePath", prefix))
 	}
 
-	if reporter.ColorizeOutput() {
-		result = append(result, fmt.Sprintf("--%scolor", prefix))
+	if ! reporter.ColorizeOutput() {
+		result = append(result, fmt.Sprintf("--%snoColor", prefix))
 	}
 
 	if reporter.SlowSpecThreshold > 0 {


### PR DESCRIPTION
If a user compiles their test binary with an older version of the Ginkgo
library, but uses a newer version of the Ginkgo test runner to run it,
they will not be able to pass the new flag `--color` to the test binary.
Instead, we should continue pasing the `--noColor` flag to preserve
compatibility.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@onsi this may be the correct solution for the problems detected by @james-lawrence and  @cscatolini in https://github.com/onsi/ginkgo/pull/328

@james-lawrence,  @cscatolini could you try this patch set out to test?