### PR TITLE
print location of test suite that failed to report back

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -392,7 +392,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 	|                                                                   |
 	 -------------------------------------------------------------------
 `)
-
+		fmt.Println(t.Suite.PackageName, "timed out. path:", t.Suite.Path)
 		os.Stdout.Sync()
 
 		for _, writer := range writers {


### PR DESCRIPTION
fixes #327

did a pretty lazy approach, let me know if you have any preferences on the output formatting.