### PR TITLE
Allow coverage to be displayed for focused specs

### DIFF
--- a/ginkgo/run_command.go
+++ b/ginkgo/run_command.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
+
+	"io/ioutil"
+	"path/filepath"
 
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/ginkgo/interrupthandler"
 	"github.com/onsi/ginkgo/ginkgo/testrunner"
 	"github.com/onsi/ginkgo/types"
-	"io/ioutil"
-	"path/filepath"
 )
 
 func BuildRunCommand() *Command {
@@ -121,7 +123,7 @@ func (r *SpecRunner) RunSpecs(args []string, additionalArgs []string) {
 	fmt.Printf("\nGinkgo ran %d %s in %s\n", numSuites, pluralizedWord("suite", "suites", numSuites), time.Since(t))
 
 	if runResult.Passed {
-		if runResult.HasProgrammaticFocus {
+		if runResult.HasProgrammaticFocus && strings.TrimSpace(os.Getenv("GINKGO_EDITOR_INTEGRATION")) == "" {
 			fmt.Printf("Test Suite Passed\n")
 			fmt.Printf("Detected Programmatic Focus - setting exit status to %d\n", types.GINKGO_FOCUS_EXIT_CODE)
 			os.Exit(types.GINKGO_FOCUS_EXIT_CODE)

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -216,7 +216,7 @@ func RunSpecsWithCustomReporters(t GinkgoTestingT, description string, specRepor
 		reporters[i] = reporter
 	}
 	passed, hasFocusedTests := globalSuite.Run(t, description, reporters, writer, config.GinkgoConfig)
-	if passed && hasFocusedTests {
+	if passed && hasFocusedTests && strings.TrimSpace(os.Getenv("GINKGO_EDITOR_INTEGRATION")) == "" {
 		fmt.Println("PASS | FOCUSED")
 		os.Exit(types.GINKGO_FOCUS_EXIT_CODE)
 	}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"runtime"
 	"strings"
@@ -97,6 +98,24 @@ var _ = Describe("Running Specs", func() {
 			Ω(output).Should(ContainSubstring("Running Suite: More_ginkgo_tests Suite"))
 			Ω(output).Should(ContainSubstring("Test Suite Passed"))
 			Ω(output).Should(ContainSubstring("Detected Programmatic Focus - setting exit status to %d", types.GINKGO_FOCUS_EXIT_CODE))
+		})
+
+		Context("when the GINKGO_EDITOR_INTEGRATION environment variable is set", func() {
+			BeforeEach(func() {
+				os.Setenv("GINKGO_EDITOR_INTEGRATION", "true")
+			})
+			AfterEach(func() {
+				os.Setenv("GINKGO_EDITOR_INTEGRATION", "")
+			})
+			It("should exit with a status code of 0 to allow a coverage file to be generated", func() {
+				session := startGinkgo(tmpDir, "--noColor", "--succinct=false", "-r")
+				Eventually(session).Should(gexec.Exit(0))
+				output := string(session.Out.Contents())
+
+				Ω(output).Should(ContainSubstring("Running Suite: Passing_ginkgo_tests Suite"))
+				Ω(output).Should(ContainSubstring("Running Suite: More_ginkgo_tests Suite"))
+				Ω(output).Should(ContainSubstring("Test Suite Passed"))
+			})
 		})
 	})
 


### PR DESCRIPTION
In #205, there was lamentation! Show coverage for focused specs, we could not 😢. With this PR, it is possible to opt-in to allow coverage to be shown for focused specs.

The default behavior (failing the suite if any focusing is present, to prevent it from getting through CI) is preserved. A savvy editor integrator can transparently set the `GINKGO_EDITOR_INTEGRATION` environment variable to some non-empty value (e.g. `true`) to suppress the `197` exit code, and allow a coverage file to be generated (and thus allow coverage to be displayed in the editor).