### PR TITLE
Added Duration on GinkgoTestDescription

### DIFF
--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -149,7 +149,8 @@ type GinkgoTestDescription struct {
 	FileName   string
 	LineNumber int
 
-	Failed bool
+	Failed   bool
+	Duration time.Duration
 }
 
 //CurrentGinkgoTestDescripton returns information about the current running test.
@@ -169,6 +170,7 @@ func CurrentGinkgoTestDescription() GinkgoTestDescription {
 		FileName:       subjectCodeLocation.FileName,
 		LineNumber:     subjectCodeLocation.LineNumber,
 		Failed:         summary.HasFailureState(),
+		Duration:       summary.RunTime,
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -92,13 +92,18 @@ func (spec *Spec) Summary(suiteID string) *types.SpecSummary {
 	componentTexts[len(spec.containers)] = spec.subject.Text()
 	componentCodeLocations[len(spec.containers)] = spec.subject.CodeLocation()
 
+	runTime := spec.runTime
+	if runTime == 0 {
+		runTime = time.Since(spec.startTime)
+	}
+
 	return &types.SpecSummary{
 		IsMeasurement:          spec.IsMeasurement(),
 		NumberOfSamples:        spec.subject.Samples(),
 		ComponentTexts:         componentTexts,
 		ComponentCodeLocations: componentCodeLocations,
 		State:        spec.state,
-		RunTime:      time.Since(spec.startTime),
+		RunTime:      runTime,
 		Failure:      spec.failure,
 		Measurements: spec.measurementsReport(),
 		SuiteID:      suiteID,

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -19,6 +19,7 @@ type Spec struct {
 
 	state            types.SpecState
 	runTime          time.Duration
+	startTime        time.Time
 	failure          types.SpecFailure
 	previousFailures bool
 }
@@ -97,7 +98,7 @@ func (spec *Spec) Summary(suiteID string) *types.SpecSummary {
 		ComponentTexts:         componentTexts,
 		ComponentCodeLocations: componentCodeLocations,
 		State:        spec.state,
-		RunTime:      spec.runTime,
+		RunTime:      time.Since(spec.startTime),
 		Failure:      spec.failure,
 		Measurements: spec.measurementsReport(),
 		SuiteID:      suiteID,
@@ -118,9 +119,9 @@ func (spec *Spec) Run(writer io.Writer) {
 		spec.previousFailures = true
 	}
 
-	startTime := time.Now()
+	spec.startTime = time.Now()
 	defer func() {
-		spec.runTime = time.Since(startTime)
+		spec.runTime = time.Since(spec.startTime)
 	}()
 
 	for sample := 0; sample < spec.subject.Samples(); sample++ {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -569,6 +569,13 @@ var _ = Describe("Spec", func() {
 			Ω(summary.RunTime).Should(BeNumerically(">=", 10*time.Millisecond))
 		})
 
+		It("should have a runtime which remains consistent after spec run", func() {
+			totalRunTime := summary.RunTime
+			Ω(totalRunTime).Should(BeNumerically(">=", 10*time.Millisecond))
+
+			Consistently(func() time.Duration { return spec.Summary("suite id").RunTime }).Should(Equal(totalRunTime))
+		})
+
 		It("should not be a measurement, or have a measurement summary", func() {
 			Ω(summary.IsMeasurement).Should(BeFalse())
 			Ω(summary.Measurements).Should(BeEmpty())

--- a/internal/suite/suite_test.go
+++ b/internal/suite/suite_test.go
@@ -153,6 +153,19 @@ var _ = Describe("Suite", func() {
 				"AfterSuite",
 			}))
 		})
+		Context("When afterEach info is needed", func() {
+			AfterEach(func() {
+				description := CurrentGinkgoTestDescription()
+				Ω(description.IsMeasurement).Should(BeFalse())
+				Ω(description.FileName).Should(ContainSubstring("suite_test.go"))
+				Ω(description.Failed).Should(BeFalse())
+				Ω(description.Duration).Should(BeNumerically(">", 0))
+			})
+
+			It("provides information about the current test", func() {
+				Ω(true).To(BeTrue())
+			})
+		})
 
 		Context("when told to randomize all specs", func() {
 			BeforeEach(func() {

--- a/internal/suite/suite_test.go
+++ b/internal/suite/suite_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Suite", func() {
 				"AfterSuite",
 			}))
 		})
-		Context("When afterEach info is needed", func() {
+		Context("when in an AfterEach block", func() {
 			AfterEach(func() {
 				description := CurrentGinkgoTestDescription()
 				Ω(description.IsMeasurement).Should(BeFalse())
@@ -162,7 +162,7 @@ var _ = Describe("Suite", func() {
 				Ω(description.Duration).Should(BeNumerically(">", 0))
 			})
 
-			It("provides information about the current test", func() {
+			It("still provides information about the current test", func() {
 				Ω(true).To(BeTrue())
 			})
 		})

--- a/internal/suite/suite_test.go
+++ b/internal/suite/suite_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Suite", func() {
 			Ω(description.LineNumber).Should(BeNumerically(">", 50))
 			Ω(description.LineNumber).Should(BeNumerically("<", 150))
 			Ω(description.Failed).Should(BeFalse())
+			Ω(description.Duration).Should(BeNumerically(">", 0))
 		})
 
 		Measure("should run measurements", func(b Benchmarker) {


### PR DESCRIPTION
Hello, 

This PR adds the support to get the test Duration on the CurrentGinkgoTestDescription(). The main reason is when a test fails you know the current duration of the test.

In my particular case, when a test fails, logs can be retrieved since the test starts. So I don't need to add more verbose in the current test output. 

Regards
