### PR TITLE
Replace GOPATH in Environment

### DIFF
--- a/integration/watch_test.go
+++ b/integration/watch_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Watch", func() {
 
 	startGinkgoWithGopath := func(args ...string) *gexec.Session {
 		cmd := ginkgoCommand(rootPath, args...)
-		cmd.Env = append([]string{"GOPATH=" + rootPath + ":" + os.Getenv("GOPATH")}, os.Environ()...)
+		os.Setenv("GOPATH", rootPath+":"+os.Getenv("GOPATH"))
 		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 		Ω(err).ShouldNot(HaveOccurred())
 		return session


### PR DESCRIPTION
Previously the test GOPATH was being prepended to the existing OS
environment, which means it would be overwritten if the user had GOPATH
set. Now we replace the value of GOPATH with Setenv so it will take
precedence over any existing value.