### PR TITLE
Re-add noisySkippings flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type DefaultReporterConfigType struct {
 	NoColor           bool
 	SlowSpecThreshold float64
 	NoisyPendings     bool
+	NoisySkippings    bool
 	Succinct          bool
 	Verbose           bool
 	FullTrace         bool
@@ -90,6 +91,7 @@ func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
 	flagSet.BoolVar(&(DefaultReporterConfig.NoColor), prefix+"noColor", false, "If set, suppress color output in default reporter.")
 	flagSet.Float64Var(&(DefaultReporterConfig.SlowSpecThreshold), prefix+"slowSpecThreshold", 5.0, "(in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter.")
 	flagSet.BoolVar(&(DefaultReporterConfig.NoisyPendings), prefix+"noisyPendings", true, "If set, default reporter will shout about pending tests.")
+	flagSet.BoolVar(&(DefaultReporterConfig.NoisySkippings), prefix+"noisySkippings", true, "If set, default reporter will shout about skipping tests.")
 	flagSet.BoolVar(&(DefaultReporterConfig.Verbose), prefix+"v", false, "If set, default reporter print out all specs as they begin.")
 	flagSet.BoolVar(&(DefaultReporterConfig.Succinct), prefix+"succinct", false, "If set, default reporter prints out a very succinct report")
 	flagSet.BoolVar(&(DefaultReporterConfig.FullTrace), prefix+"trace", false, "If set, default reporter prints out the full stack trace when a failure occurs")
@@ -169,6 +171,10 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 
 	if !reporter.NoisyPendings {
 		result = append(result, fmt.Sprintf("--%snoisyPendings=false", prefix))
+	}
+
+	if !reporter.NoisySkippings {
+		result = append(result, fmt.Sprintf("--%snoisySkippings=false", prefix))
 	}
 
 	if reporter.Verbose {

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -233,7 +233,7 @@ func buildDefaultReporter() Reporter {
 	}
 }
 
-//Skip notifies Ginkgo that the current spec should be skipped.
+//Skip notifies Ginkgo that the current spec was skipped.
 func Skip(message string, callerSkip ...int) {
 	skip := 0
 	if len(callerSkip) > 0 {

--- a/internal/remote/aggregator.go
+++ b/internal/remote/aggregator.go
@@ -207,7 +207,7 @@ func (aggregator *Aggregator) announceSpec(specSummary *types.SpecSummary) {
 	case types.SpecStatePending:
 		aggregator.stenographer.AnnouncePendingSpec(specSummary, aggregator.config.NoisyPendings && !aggregator.config.Succinct)
 	case types.SpecStateSkipped:
-		aggregator.stenographer.AnnounceSkippedSpec(specSummary, aggregator.config.Succinct, aggregator.config.FullTrace)
+		aggregator.stenographer.AnnounceSkippedSpec(specSummary, aggregator.config.Succinct || !aggregator.config.NoisySkippings, aggregator.config.FullTrace)
 	case types.SpecStateTimedOut:
 		aggregator.stenographer.AnnounceSpecTimedOut(specSummary, aggregator.config.Succinct, aggregator.config.FullTrace)
 	case types.SpecStatePanicked:

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -66,7 +66,7 @@ func (reporter *DefaultReporter) SpecDidComplete(specSummary *types.SpecSummary)
 	case types.SpecStatePending:
 		reporter.stenographer.AnnouncePendingSpec(specSummary, reporter.config.NoisyPendings && !reporter.config.Succinct)
 	case types.SpecStateSkipped:
-		reporter.stenographer.AnnounceSkippedSpec(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+		reporter.stenographer.AnnounceSkippedSpec(specSummary, reporter.config.Succinct || !reporter.config.NoisySkippings, reporter.config.FullTrace)
 	case types.SpecStateTimedOut:
 		reporter.stenographer.AnnounceSpecTimedOut(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
 	case types.SpecStatePanicked:

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -28,6 +28,7 @@ var _ = Describe("DefaultReporter", func() {
 			NoColor:           false,
 			SlowSpecThreshold: 0.1,
 			NoisyPendings:     false,
+			NoisySkippings:    false,
 			Verbose:           true,
 			FullTrace:         true,
 		}
@@ -258,8 +259,8 @@ var _ = Describe("DefaultReporter", func() {
 				spec.State = types.SpecStateSkipped
 			})
 
-			It("should announce the skipped spec", func() {
-				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec, false, true)))
+			It("should announce the skipped spec, succinctly", func() {
+				Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec, true, true)))
 			})
 		})
 
@@ -307,6 +308,24 @@ var _ = Describe("DefaultReporter", func() {
 
 				It("should announce the pending spec, noisily", func() {
 					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnouncePendingSpec", spec, true)))
+				})
+			})
+		})
+
+		Context("in noisy skippings mode", func() {
+			BeforeEach(func() {
+				reporterConfig.Succinct = false
+				reporterConfig.NoisySkippings = true
+				reporter = reporters.NewDefaultReporter(reporterConfig, stenographer)
+			})
+
+			Context("When the spec is skipped", func() {
+				BeforeEach(func() {
+					spec.State = types.SpecStateSkipped
+				})
+
+				It("should announce the skipped spec, noisily", func() {
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSkippedSpec", spec, false, true)))
 				})
 			})
 		})


### PR DESCRIPTION
This mostly reverts commit d981d36e9884231afa909627b9c275e4ba678f90,
but changes the behavior slightly so either the succinct flag or
noisySkippings=false will suppress noisy output for skip.

Signed-off-by: Jamie McAtamney <jmcatamney@pivotal.io>

Solves https://github.com/onsi/ginkgo/issues/376