### PR TITLE
Added Stdin support to TestRunner

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -431,6 +431,7 @@ func (t *TestRunner) cmd(ginkgoArgs []string, stream io.Writer, node int) *exec.
 	cmd.Dir = t.Suite.Path
 	cmd.Stderr = io.MultiWriter(stream, t.stderr)
 	cmd.Stdout = stream
+	cmd.Stdin = os.Stdin
 
 	return cmd
 }


### PR DESCRIPTION
Hello! 

A minimal change that allows using stdin on ginkgo test runner. 

The main reason to allow Stdin is to be able to wait for test on a custom fail function, that allows developers to debug in some particular circumstances. 

Regards
