### PR TITLE
Prevent data --race error when recording a benchmark value from multiple go routines

### DIFF
--- a/internal/leafnodes/benchmarker.go
+++ b/internal/leafnodes/benchmarker.go
@@ -35,15 +35,15 @@ func (b *benchmarker) Time(name string, body func(), info ...interface{}) (elaps
 }
 
 func (b *benchmarker) RecordValue(name string, value float64, info ...interface{}) {
-	measurement := b.getMeasurement(name, "Smallest", " Largest", " Average", "", 3, info...)
 	b.mu.Lock()
+	measurement := b.getMeasurement(name, "Smallest", " Largest", " Average", "", 3, info...)
 	defer b.mu.Unlock()
 	measurement.Results = append(measurement.Results, value)
 }
 
 func (b *benchmarker) RecordValueWithPrecision(name string, value float64, units string, precision int, info ...interface{}) {
-	measurement := b.getMeasurement(name, "Smallest", " Largest", " Average", units, precision, info...)
 	b.mu.Lock()
+	measurement := b.getMeasurement(name, "Smallest", " Largest", " Average", units, precision, info...)
 	defer b.mu.Unlock()
 	measurement.Results = append(measurement.Results, value)
 }


### PR DESCRIPTION
Within our tests we are recording benchmark values from multiple go routines. However we encounter data race conditions due to the lack of locking around the benchmark map`b.measurements[name]` 