### PR TITLE
Imports in generated code should follow conventions

### DIFF
--- a/ginkgo/bootstrap_command.go
+++ b/ginkgo/bootstrap_command.go
@@ -43,10 +43,10 @@ func BuildBootstrapCommand() *Command {
 var bootstrapText = `package {{.Package}}
 
 import (
+	"testing"
+
 	{{.GinkgoImport}}
 	{{.GomegaImport}}
-
-	"testing"
 )
 
 func Test{{.FormattedName}}(t *testing.T) {
@@ -58,11 +58,11 @@ func Test{{.FormattedName}}(t *testing.T) {
 var agoutiBootstrapText = `package {{.Package}}
 
 import (
+	"testing"
+
 	{{.GinkgoImport}}
 	{{.GomegaImport}}
 	"github.com/sclevine/agouti"
-
-	"testing"
 )
 
 func Test{{.FormattedName}}(t *testing.T) {

--- a/ginkgo/generate_command.go
+++ b/ginkgo/generate_command.go
@@ -34,10 +34,10 @@ func BuildGenerateCommand() *Command {
 var specText = `package {{.Package}}
 
 import (
-	{{if .DotImportPackage}}. "{{.PackageImportPath}}"{{end}}
-
 	{{if .IncludeImports}}. "github.com/onsi/ginkgo"{{end}}
 	{{if .IncludeImports}}. "github.com/onsi/gomega"{{end}}
+
+	{{if .DotImportPackage}}. "{{.PackageImportPath}}"{{end}}
 )
 
 var _ = Describe("{{.Subject}}", func() {
@@ -45,15 +45,15 @@ var _ = Describe("{{.Subject}}", func() {
 })
 `
 
-var agoutiSpecText = `package {{.Package}}_test
+var agoutiSpecText = `package {{.Package}}
 
 import (
-	{{if .DotImportPackage}}. "{{.PackageImportPath}}"{{end}}
-
 	{{if .IncludeImports}}. "github.com/onsi/ginkgo"{{end}}
 	{{if .IncludeImports}}. "github.com/onsi/gomega"{{end}}
-	. "github.com/sclevine/agouti/matchers"
 	"github.com/sclevine/agouti"
+	. "github.com/sclevine/agouti/matchers"
+
+	{{if .DotImportPackage}}. "{{.PackageImportPath}}"{{end}}
 )
 
 var _ = Describe("{{.Subject}}", func() {

--- a/integration/_fixtures/convert_goldmasters/nested_suite_test.go
+++ b/integration/_fixtures/convert_goldmasters/nested_suite_test.go
@@ -1,10 +1,10 @@
 package nested_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestNested(t *testing.T) {

--- a/integration/_fixtures/convert_goldmasters/suite_test.go
+++ b/integration/_fixtures/convert_goldmasters/suite_test.go
@@ -1,10 +1,10 @@
 package tmp_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestConvertFixtures(t *testing.T) {


### PR DESCRIPTION
For https://github.com/onsi/ginkgo/issues/396

This PR changes the ordering of the imports in the code generated by `ginkgo bootstrap` and `ginkgo generate` to follow Go conventions of grouping by standard library imports, then 3rd party imports, then by local imports.

This PR also removes a superfluous `_test` from the package name generated by `ginkgo generate -agouti`.