### PR TITLE
Use rouge as docs highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 baseurl: /ginkgo
 safe: true
 lsi: false
-highlighter: pygments
+highlighter: rouge
 markdown: kramdown


### PR DESCRIPTION
pygments is no longer supported by GitHub

[fixes #397]