### PR TITLE
Build with go 1.9 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go:
-  - 1.5.x
   - 1.6.x
   - 1.7.x
   - 1.8.x
+  - 1.9.x
 
 install:
   - go get -v -t ./...


### PR DESCRIPTION
Gomega builds with 1.6-1.9, so let's be consistent. Also, drop support
for 1.5 since it's really old