### PR TITLE
Also process FSpecify when unfocusing

### DIFF
--- a/ginkgo/unfocus_command.go
+++ b/ginkgo/unfocus_command.go
@@ -27,6 +27,7 @@ func unfocusSpecs([]string, []string) {
 	unfocus("DescribeTable")
 	unfocus("Entry")
 	unfocus("Specify")
+	unfocus("When")
 }
 
 func unfocus(component string) {

--- a/ginkgo/unfocus_command.go
+++ b/ginkgo/unfocus_command.go
@@ -26,6 +26,7 @@ func unfocusSpecs([]string, []string) {
 	unfocus("Measure")
 	unfocus("DescribeTable")
 	unfocus("Entry")
+	unfocus("Specify")
 }
 
 func unfocus(component string) {

--- a/integration/_fixtures/focused_fixture/focused_fixture_test.go
+++ b/integration/_fixtures/focused_fixture/focused_fixture_test.go
@@ -18,6 +18,12 @@ var _ = Describe("FocusedFixture", func() {
 		})
 	})
 
+	FWhen("focused", func() {
+		It("focused", func() {
+
+		})
+	})
+
 	FIt("focused", func() {
 
 	})

--- a/integration/_fixtures/focused_fixture/focused_fixture_test.go
+++ b/integration/_fixtures/focused_fixture/focused_fixture_test.go
@@ -22,6 +22,10 @@ var _ = Describe("FocusedFixture", func() {
 
 	})
 
+	FSpecify("focused", func() {
+
+	})
+
 	FMeasure("focused", func(b Benchmarker) {
 
 	}, 2)

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -354,8 +354,8 @@ var _ = Describe("Subcommand", func() {
 			Eventually(session).Should(gexec.Exit(types.GINKGO_FOCUS_EXIT_CODE))
 			output := session.Out.Contents()
 
-			Ω(output).Should(ContainSubstring("6 Passed"))
-			Ω(output).Should(ContainSubstring("5 Skipped"))
+			Ω(string(output)).Should(ContainSubstring("7 Passed"))
+			Ω(string(output)).Should(ContainSubstring("5 Skipped"))
 
 			session = startGinkgo(pathToTest, "blur")
 			Eventually(session).Should(gexec.Exit(0))
@@ -363,8 +363,8 @@ var _ = Describe("Subcommand", func() {
 			session = startGinkgo(pathToTest, "--noColor")
 			Eventually(session).Should(gexec.Exit(0))
 			output = session.Out.Contents()
-			Ω(output).Should(ContainSubstring("11 Passed"))
-			Ω(output).Should(ContainSubstring("0 Skipped"))
+			Ω(string(output)).Should(ContainSubstring("12 Passed"))
+			Ω(string(output)).Should(ContainSubstring("0 Skipped"))
 		})
 	})
 

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Subcommand", func() {
 			Eventually(session).Should(gexec.Exit(types.GINKGO_FOCUS_EXIT_CODE))
 			output := session.Out.Contents()
 
-			Ω(string(output)).Should(ContainSubstring("7 Passed"))
+			Ω(string(output)).Should(ContainSubstring("8 Passed"))
 			Ω(string(output)).Should(ContainSubstring("5 Skipped"))
 
 			session = startGinkgo(pathToTest, "blur")
@@ -363,7 +363,7 @@ var _ = Describe("Subcommand", func() {
 			session = startGinkgo(pathToTest, "--noColor")
 			Eventually(session).Should(gexec.Exit(0))
 			output = session.Out.Contents()
-			Ω(string(output)).Should(ContainSubstring("12 Passed"))
+			Ω(string(output)).Should(ContainSubstring("13 Passed"))
 			Ω(string(output)).Should(ContainSubstring("0 Skipped"))
 		})
 	})


### PR DESCRIPTION
Closes #433.

This adds `FSpecify` to the list of unfocus components, with a hopefully appropriate test.

I took the liberty to cast the tested output to strings, so failures are more readable (Go otherwise prints the output as a slice of bytes).