### PR TITLE
Do not set the run time of a spec when the dryRun flag is used

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -98,7 +98,7 @@ func (spec *Spec) Summary(suiteID string) *types.SpecSummary {
 	componentCodeLocations[len(spec.containers)] = spec.subject.CodeLocation()
 
 	runTime := spec.runTime
-	if runTime == 0 {
+	if runTime == 0 && !spec.startTime.IsZero() {
 		runTime = time.Since(spec.startTime)
 	}
 

--- a/internal/specrunner/spec_runner_test.go
+++ b/internal/specrunner/spec_runner_test.go
@@ -235,6 +235,13 @@ var _ = Describe("Spec Runner", func() {
 				Ω(reporter1.EndSummary.NumberOfPassedSpecs).Should(Equal(0))
 				Ω(reporter1.EndSummary.NumberOfFailedSpecs).Should(Equal(0))
 			})
+
+			It("should not report a slow test", func() {
+				summaries := reporter1.SpecSummaries
+				for _, s := range summaries {
+					Expect(s.RunTime).To(BeZero())
+				}
+			})
 		})
 	})
 


### PR DESCRIPTION
Fixes https://github.com/onsi/ginkgo/issues/436