### PR TITLE
Add a `RELEASING.md` guide for creating a release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,8 @@
+A Ginkgo release is a tagged git sha and a GitHub release.  To cut a release:
+
+1. Ensure CHANGELOG.md is up to date.
+1. Update `VERSION` in `config/config.go`
+1. Create a commit with the version number as the commit message (e.g. `v1.3.0`)
+1. Tag the commit with the version number as the tag name (e.g. `v1.3.0`)
+1. Push the commit and tag to GitHub
+1. Create a new [GitHub release](https://help.github.com/articles/creating-releases/) with the version number as the tag  (e.g. `v1.3.0`).  List the key changes in the release notes.


### PR DESCRIPTION
- resolves https://github.com/onsi/ginkgo/issues/421
- based on https://github.com/onsi/gomega/blob/master/RELEASING.md
- only @onsi has released so far, so it would make sense for him to review this
- @williammartin, a releasing guide is a step in the right direction, but how would be be if there were a releasing script that did it all for you?  Let's discuss...