### PR TITLE
Fix test using gcflags

### DIFF
--- a/integration/_fixtures/flags_tests/flags_test.go
+++ b/integration/_fixtures/flags_tests/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	remapped "math"
+	_ "math/cmplx"
 	"time"
 
 	. "github.com/onsi/ginkgo"

--- a/integration/flags_test.go
+++ b/integration/flags_test.go
@@ -213,6 +213,7 @@ var _ = Describe("Flags Specs", func() {
 		output = regextest("-regexScansFilePath=false", "-focus=/passing/") // nothing gets focused (nothing runs)
 		Ω(output).Should(ContainSubstring("0 of 4 Specs"))
 	})
+
 	It("should honor compiler flags", func() {
 		session := startGinkgo(pathToTest, "-gcflags=-importmap 'math=math/cmplx'")
 		Eventually(session).Should(gexec.Exit(types.GINKGO_FOCUS_EXIT_CODE))


### PR DESCRIPTION
Packages need to be already imported to be remapped using the
`-importmap` compiler flag.

Signed-off-by: Andrea Nodari <anodari@pivotal.io>