### PR TITLE
Fail fast when the outputdir of combined coverage profile does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 - When using custom reporters register the custom reporters *before* the default reporter.  This allows users to see the output of any print statements in their customer reporters. [#365]
+- When running a test and calculating the coverage using the `-coverprofile` and `-outputdir` flags, Ginkgo fails with an error if the directory does not exist. This is due to an [issue in go 1.10](https://github.com/golang/go/issues/24588) [#446]
 
 ## 1.4.0 7/16/2017
 

--- a/ginkgo/run_command.go
+++ b/ginkgo/run_command.go
@@ -104,20 +104,23 @@ func (r *SpecRunner) RunSpecs(args []string, additionalArgs []string) {
 		runResult, numSuites = r.suiteRunner.RunSuites(randomizedRunners, r.commandFlags.NumCompilers, r.commandFlags.KeepGoing, nil)
 	}
 
+	for _, runner := range runners {
+		runner.CleanUp()
+	}
+
 	if r.isInCoverageMode() {
 		if r.getOutputDir() != "" {
 			// If coverprofile is set, combine coverages
 			if r.getCoverprofile() != "" {
-				r.combineCoverprofiles(runners)
+				if err := r.combineCoverprofiles(runners); err != nil {
+					fmt.Println(err.Error())
+					os.Exit(1)
+				}
 			} else {
 				// Just move them
 				r.moveCoverprofiles(runners)
 			}
 		}
-	}
-
-	for _, runner := range runners {
-		runner.CleanUp()
 	}
 
 	fmt.Printf("\nGinkgo ran %d %s in %s\n", numSuites, pluralizedWord("suite", "suites", numSuites), time.Since(t))
@@ -151,19 +154,21 @@ func (r *SpecRunner) moveCoverprofiles(runners []*testrunner.TestRunner) {
 }
 
 // Combines all generated profiles in the specified directory
-func (r *SpecRunner) combineCoverprofiles(runners []*testrunner.TestRunner) {
+func (r *SpecRunner) combineCoverprofiles(runners []*testrunner.TestRunner) error {
 
 	path, _ := filepath.Abs(r.getOutputDir())
+	if !fileExists(path) {
+		return fmt.Errorf("Unable to create combined profile, outputdir does not exist: %s", r.getOutputDir())
+	}
 
 	fmt.Println("path is " + path)
-	os.MkdirAll(path, os.ModePerm)
 
 	combined, err := os.OpenFile(filepath.Join(path, r.getCoverprofile()),
 		os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 
 	if err != nil {
 		fmt.Printf("Unable to create combined profile, %v\n", err)
-		return
+		return nil // non-fatal error
 	}
 
 	for _, runner := range runners {
@@ -171,18 +176,19 @@ func (r *SpecRunner) combineCoverprofiles(runners []*testrunner.TestRunner) {
 
 		if err != nil {
 			fmt.Printf("Unable to read coverage file %s to combine, %v\n", runner.CoverageFile, err)
-			return
+			return nil // non-fatal error
 		}
 
 		_, err = combined.Write(contents)
 
 		if err != nil {
 			fmt.Printf("Unable to append to coverprofile, %v\n", err)
-			return
+			return nil // non-fatal error
 		}
 	}
 
 	fmt.Println("All profiles combined")
+	return nil
 }
 
 func (r *SpecRunner) isInCoverageMode() bool {

--- a/integration/coverage_test.go
+++ b/integration/coverage_test.go
@@ -112,17 +112,12 @@ var _ = Describe("Coverage Specs", func() {
 		os.RemoveAll("./_fixtures/combined_coverage_fixture/coverage.txt")
 	})
 
-	It("Creates directories in path if they don't exist", func() {
+	It("Fails with an error if output dir and coverprofile were set, but the output dir did not exist", func() {
 		session := startGinkgo("./_fixtures/combined_coverage_fixture", "-outputdir=./all/profiles/here", "-r", "-cover", "-coverprofile=coverage.txt")
 
-		defer os.RemoveAll("./_fixtures/combined_coverage_fixture/all")
-		defer os.RemoveAll("./_fixtures/combined_coverage_fixture/coverage.txt")
-
-		Eventually(session).Should(gexec.Exit(0))
-
-		_, err := os.Stat("./_fixtures/combined_coverage_fixture/all/profiles/here/coverage.txt")
-
-		Ω(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(1))
+		output := session.Out.Contents()
+		Ω(string(output)).Should(ContainSubstring("Unable to create combined profile, outputdir does not exist: ./all/profiles/here"))
 	})
 
 	It("Moves coverages if only output dir was set", func() {


### PR DESCRIPTION
This is a workaround for a change in behaviour between go <= 1.9 and go
1.10.

Prior to go 1.9, compiling a test would not fail if the specified
output dir does not exist. However, it does fail in go 1.10.

By failing when the the directory does not exist, we have a consistent
behaviour withing go versions.

See also https://github.com/golang/go/issues/24588