### PR TITLE
Added name field to jUnit reported testsuite

### DIFF
--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -21,6 +21,7 @@ import (
 type JUnitTestSuite struct {
 	XMLName   xml.Name        `xml:"testsuite"`
 	TestCases []JUnitTestCase `xml:"testcase"`
+	Name      string          `xml:"name,attr"`
 	Tests     int             `xml:"tests,attr"`
 	Failures  int             `xml:"failures,attr"`
 	Time      float64         `xml:"time,attr"`
@@ -59,6 +60,7 @@ func NewJUnitReporter(filename string) *JUnitReporter {
 
 func (reporter *JUnitReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
 	reporter.suite = JUnitTestSuite{
+		Name:      summary.SuiteDescription,
 		TestCases: []JUnitTestCase{},
 	}
 	reporter.testSuiteName = summary.SuiteDescription

--- a/reporters/junit_reporter_test.go
+++ b/reporters/junit_reporter_test.go
@@ -76,6 +76,7 @@ var _ = Describe("JUnit Reporter", func() {
 
 		It("should record the test as passing", func() {
 			output := readOutputFile()
+			Ω(output.Name).Should(Equal("My test suite"))
 			Ω(output.Tests).Should(Equal(1))
 			Ω(output.Failures).Should(Equal(0))
 			Ω(output.Time).Should(Equal(10.0))
@@ -112,6 +113,7 @@ var _ = Describe("JUnit Reporter", func() {
 
 		It("should record the test as having failed", func() {
 			output := readOutputFile()
+			Ω(output.Name).Should(Equal("My test suite"))
 			Ω(output.Tests).Should(Equal(1))
 			Ω(output.Failures).Should(Equal(1))
 			Ω(output.Time).Should(Equal(10.0))
@@ -150,6 +152,7 @@ var _ = Describe("JUnit Reporter", func() {
 
 		It("should record the test as having failed", func() {
 			output := readOutputFile()
+			Ω(output.Name).Should(Equal("My test suite"))
 			Ω(output.Tests).Should(Equal(1))
 			Ω(output.Failures).Should(Equal(1))
 			Ω(output.Time).Should(Equal(10.0))
@@ -200,6 +203,7 @@ var _ = Describe("JUnit Reporter", func() {
 
 			It("should record test as failing", func() {
 				output := readOutputFile()
+				Ω(output.Name).Should(Equal("My test suite"))
 				Ω(output.Tests).Should(Equal(1))
 				Ω(output.Failures).Should(Equal(1))
 				Ω(output.Time).Should(Equal(10.0))


### PR DESCRIPTION
JUnit file format specification implies presense of "name" attribute. So, TeamCity parser substitutes "null" instead of Suite Name. PR fixes this issue.