### PR TITLE
Add an extra new line after reporting spec run completion

### DIFF
--- a/reporters/stenographer/stenographer.go
+++ b/reporters/stenographer/stenographer.go
@@ -178,7 +178,7 @@ func (s *consoleStenographer) AnnounceSpecRunCompletion(summary *types.SuiteSumm
 	}
 
 	s.print(0,
-		"%s -- %s | %s | %s | %s ",
+		"%s -- %s | %s | %s | %s\n",
 		status,
 		s.colorize(greenColor+boldStyle, "%d Passed", summary.NumberOfPassedSpecs),
 		s.colorize(redColor+boldStyle, "%d Failed", summary.NumberOfFailedSpecs)+flakes,


### PR DESCRIPTION
Otherwise, `cmd/test2json` is not able to parse Test Passed event that is added by `cmd/test` just after spec completion

Fixes #447