### PR TITLE
Update fixtures to work using go1.10

### DIFF
--- a/integration/_fixtures/coverage_fixture/coverage.go
+++ b/integration/_fixtures/coverage_fixture/coverage.go
@@ -1,5 +1,9 @@
 package coverage_fixture
 
+import (
+	_ "github.com/onsi/ginkgo/integration/_fixtures/coverage_fixture/external_coverage_fixture"
+)
+
 func A() string {
 	return "A"
 }


### PR DESCRIPTION
In go 1.10 the `-coverpkg` flag does not load new packages, but allow
users to provide a list of patterns (see
https://golang.org/doc/go1.10#test). For this reason, we need to import
the the package in the fixture.