### PR TITLE
Ignore packages whose tests are all ignored by go

### DIFF
--- a/ginkgo/testsuite/test_suite.go
+++ b/ginkgo/testsuite/test_suite.go
@@ -53,7 +53,7 @@ func SuitesInDir(dir string, recurse bool) []TestSuite {
 	}
 
 	files, _ := ioutil.ReadDir(dir)
-	re := regexp.MustCompile(`_test\.go$`)
+	re := regexp.MustCompile(`^[^._].*_test\.go$`)
 	for _, file := range files {
 		if !file.IsDir() && re.Match([]byte(file.Name())) {
 			suites = append(suites, New(dir, files))

--- a/ginkgo/testsuite/testsuite_test.go
+++ b/ginkgo/testsuite/testsuite_test.go
@@ -51,6 +51,10 @@ var _ = Describe("TestSuite", func() {
 		//non-go files in a nested directory
 		writeFile("/redherring", "big_test.jpg", "package ginkgo", 0666)
 
+		//ginkgo tests in ignored go files
+		writeFile("/ignored", ".ignore_dot_test.go", `import "github.com/onsi/ginkgo"`, 0666)
+		writeFile("/ignored", "_ignore_underscore_test.go", `import "github.com/onsi/ginkgo"`, 0666)
+
 		//non-ginkgo tests in a nested directory
 		writeFile("/professorplum", "professorplum_test.go", `import "testing"`, 0666)
 
@@ -137,6 +141,13 @@ var _ = Describe("TestSuite", func() {
 				Ω(suites[0].PackageName).Should(Equal("colonelmustard"))
 				Ω(suites[0].IsGinkgo).Should(BeTrue())
 				Ω(suites[0].Precompiled).Should(BeFalse())
+			})
+		})
+
+		Context("when there are ginkgo tests that are ignored by go in the specified directory ", func() {
+			It("should come up empty", func() {
+				suites := SuitesInDir(filepath.Join(tmpDir, "ignored"), false)
+				Ω(suites).Should(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
When a package contains only tests in go source code that are ignored (filenames being with `.` or `_`) I think ginkgo ought to avoid selecting this package for 2 reasons: 

1. the tests won't be compiled
2. if all other (non-test) `*.go` files in a packager are also ignored this leads to a failure: `can't load package: package X: no Go files in /path/to/X`