### PR TITLE
Increase eventually timeout to 30s

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -19,7 +19,7 @@ var tmpDir string
 var pathToGinkgo string
 
 func TestIntegration(t *testing.T) {
-	SetDefaultEventuallyTimeout(15 * time.Second)
+	SetDefaultEventuallyTimeout(30 * time.Second)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Suite")
 }


### PR DESCRIPTION
In some environments ginkgo is very slow and setting the limit to 15s
causes the tests to be flaky.

Fixes #478