### PR TITLE
Make generated Junit file compatable with "Maven Surefire"

### DIFF
--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -121,7 +121,7 @@ func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 
 func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	reporter.suite.Tests = summary.NumberOfSpecsThatWillBeRun
-	reporter.suite.Time = math.Round(summary.RunTime.Seconds() * 1000 / 1000)
+	reporter.suite.Time = math.Trunc(summary.RunTime.Seconds() * 1000 / 1000)
 	reporter.suite.Failures = summary.NumberOfFailedSpecs
 	reporter.suite.Errors = 0
 	file, err := os.Create(reporter.filename)

--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -11,6 +11,7 @@ package reporters
 import (
 	"encoding/xml"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -24,6 +25,7 @@ type JUnitTestSuite struct {
 	Name      string          `xml:"name,attr"`
 	Tests     int             `xml:"tests,attr"`
 	Failures  int             `xml:"failures,attr"`
+	Errors    int             `xml:"errors,attr"`
 	Time      float64         `xml:"time,attr"`
 }
 
@@ -119,8 +121,9 @@ func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 
 func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	reporter.suite.Tests = summary.NumberOfSpecsThatWillBeRun
-	reporter.suite.Time = summary.RunTime.Seconds()
+	reporter.suite.Time = math.Round(summary.RunTime.Seconds() * 1000 / 1000)
 	reporter.suite.Failures = summary.NumberOfFailedSpecs
+	reporter.suite.Errors = 0
 	file, err := os.Create(reporter.filename)
 	if err != nil {
 		fmt.Printf("Failed to create JUnit report file: %s\n\t%s", reporter.filename, err.Error())

--- a/reporters/junit_reporter_test.go
+++ b/reporters/junit_reporter_test.go
@@ -19,6 +19,7 @@ var _ = Describe("JUnit Reporter", func() {
 		outputFile string
 		reporter   Reporter
 	)
+	testSuiteTime := 12345 * time.Millisecond
 
 	readOutputFile := func() reporters.JUnitTestSuite {
 		bytes, err := ioutil.ReadFile(outputFile)
@@ -70,7 +71,7 @@ var _ = Describe("JUnit Reporter", func() {
 			reporter.SpecSuiteDidEnd(&types.SuiteSummary{
 				NumberOfSpecsThatWillBeRun: 1,
 				NumberOfFailedSpecs:        0,
-				RunTime:                    10 * time.Second,
+				RunTime:                    testSuiteTime,
 			})
 		})
 
@@ -79,7 +80,8 @@ var _ = Describe("JUnit Reporter", func() {
 			Ω(output.Name).Should(Equal("My test suite"))
 			Ω(output.Tests).Should(Equal(1))
 			Ω(output.Failures).Should(Equal(0))
-			Ω(output.Time).Should(Equal(10.0))
+			Ω(output.Time).Should(Equal(12.0))
+			Ω(output.Errors).Should(Equal(0))
 			Ω(output.TestCases).Should(HaveLen(1))
 			Ω(output.TestCases[0].Name).Should(Equal("A B C"))
 			Ω(output.TestCases[0].ClassName).Should(Equal("My test suite"))
@@ -107,7 +109,7 @@ var _ = Describe("JUnit Reporter", func() {
 			reporter.SpecSuiteDidEnd(&types.SuiteSummary{
 				NumberOfSpecsThatWillBeRun: 1,
 				NumberOfFailedSpecs:        1,
-				RunTime:                    10 * time.Second,
+				RunTime:                    testSuiteTime,
 			})
 		})
 
@@ -116,7 +118,8 @@ var _ = Describe("JUnit Reporter", func() {
 			Ω(output.Name).Should(Equal("My test suite"))
 			Ω(output.Tests).Should(Equal(1))
 			Ω(output.Failures).Should(Equal(1))
-			Ω(output.Time).Should(Equal(10.0))
+			Ω(output.Time).Should(Equal(12.0))
+			Ω(output.Errors).Should(Equal(0))
 			Ω(output.TestCases[0].Name).Should(Equal("BeforeSuite"))
 			Ω(output.TestCases[0].Time).Should(Equal(3.0))
 			Ω(output.TestCases[0].ClassName).Should(Equal("My test suite"))
@@ -146,7 +149,7 @@ var _ = Describe("JUnit Reporter", func() {
 			reporter.SpecSuiteDidEnd(&types.SuiteSummary{
 				NumberOfSpecsThatWillBeRun: 1,
 				NumberOfFailedSpecs:        1,
-				RunTime:                    10 * time.Second,
+				RunTime:                    testSuiteTime,
 			})
 		})
 
@@ -155,7 +158,8 @@ var _ = Describe("JUnit Reporter", func() {
 			Ω(output.Name).Should(Equal("My test suite"))
 			Ω(output.Tests).Should(Equal(1))
 			Ω(output.Failures).Should(Equal(1))
-			Ω(output.Time).Should(Equal(10.0))
+			Ω(output.Time).Should(Equal(12.0))
+			Ω(output.Errors).Should(Equal(0))
 			Ω(output.TestCases[0].Name).Should(Equal("AfterSuite"))
 			Ω(output.TestCases[0].Time).Should(Equal(3.0))
 			Ω(output.TestCases[0].ClassName).Should(Equal("My test suite"))
@@ -197,7 +201,7 @@ var _ = Describe("JUnit Reporter", func() {
 				reporter.SpecSuiteDidEnd(&types.SuiteSummary{
 					NumberOfSpecsThatWillBeRun: 1,
 					NumberOfFailedSpecs:        1,
-					RunTime:                    10 * time.Second,
+					RunTime:                    testSuiteTime,
 				})
 			})
 
@@ -206,7 +210,8 @@ var _ = Describe("JUnit Reporter", func() {
 				Ω(output.Name).Should(Equal("My test suite"))
 				Ω(output.Tests).Should(Equal(1))
 				Ω(output.Failures).Should(Equal(1))
-				Ω(output.Time).Should(Equal(10.0))
+				Ω(output.Time).Should(Equal(12.0))
+				Ω(output.Errors).Should(Equal(0))
 				Ω(output.TestCases[0].Name).Should(Equal("A B C"))
 				Ω(output.TestCases[0].ClassName).Should(Equal("My test suite"))
 				Ω(output.TestCases[0].FailureMessage.Type).Should(Equal(specStateCase.message))
@@ -234,7 +239,7 @@ var _ = Describe("JUnit Reporter", func() {
 				reporter.SpecSuiteDidEnd(&types.SuiteSummary{
 					NumberOfSpecsThatWillBeRun: 1,
 					NumberOfFailedSpecs:        0,
-					RunTime:                    10 * time.Second,
+					RunTime:                    testSuiteTime,
 				})
 			})
 
@@ -242,7 +247,8 @@ var _ = Describe("JUnit Reporter", func() {
 				output := readOutputFile()
 				Ω(output.Tests).Should(Equal(1))
 				Ω(output.Failures).Should(Equal(0))
-				Ω(output.Time).Should(Equal(10.0))
+				Ω(output.Time).Should(Equal(12.0))
+				Ω(output.Errors).Should(Equal(0))
 				Ω(output.TestCases[0].Name).Should(Equal("A B C"))
 				Ω(output.TestCases[0].Skipped).ShouldNot(BeNil())
 			})


### PR DESCRIPTION
- add errors attribute to `testsuite`, currently, I will set 0,
but I think Ginkgo must report failures under setup and teardown
methods as errors and not as failures
- cut `testsuite` timestamp to three digits after the dot

Fixes #486 

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>