### PR TITLE
Fix ginkgo run with Golang 1.10 snap archive on Ubuntu 18.04

### DIFF
--- a/ginkgo/testrunner/build_args.go
+++ b/ginkgo/testrunner/build_args.go
@@ -1,0 +1,7 @@
+// +build go1.10
+
+package testrunner
+
+var (
+	buildArgs = []string{"test", "-c"}
+)

--- a/ginkgo/testrunner/build_args_old.go
+++ b/ginkgo/testrunner/build_args_old.go
@@ -1,0 +1,7 @@
+// +build !go1.10
+
+package testrunner
+
+var (
+	buildArgs = []string{"test", "-c", "-i"}
+)

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -64,7 +64,9 @@ func (t *TestRunner) Compile() error {
 }
 
 func (t *TestRunner) BuildArgs(path string) []string {
-	args := []string{"test", "-c", "-i", "-o", path, t.Suite.Path}
+	args := make([]string, len(buildArgs), len(buildArgs)+3)
+	copy(args, buildArgs)
+	args = append(args, "-o", path, t.Suite.Path)
 
 	if t.getCoverMode() != "" {
 		args = append(args, "-cover", fmt.Sprintf("-covermode=%s", t.getCoverMode()))

--- a/ginkgo/testrunner/test_runner_test.go
+++ b/ginkgo/testrunner/test_runner_test.go
@@ -36,10 +36,13 @@ var _ = Describe("TestRunner", func() {
 		tr := testrunner.New(testsuite.TestSuite{}, 1, false, 0, opts, []string{})
 
 		args := tr.BuildArgs(".")
+		// Remove the "-i" argument; This is discarded in Golang 1.10+.
+		if args[2] == "-i" {
+			args = append(args[0:2], args[3:]...)
+		}
 		Ω(args).Should(Equal([]string{
 			"test",
 			"-c",
-			"-i",
 			"-o",
 			".",
 			"",


### PR DESCRIPTION
Since Golang 1.10, this option should no longer be required:

https://golang.org/doc/go1.10#build

> The old advice to add the -i flag for speed, as in go build -i or go
test -i, is no longer necessary: builds run just as fast without -i. For
more details, see go help cache.

Furthermore, it creates issues like the below when running ginkgo
against a snap-installed version of Golang 1.10 on Ubuntu 18.04:

```
$ ginkgo build
Compiling test...
Failed to compile test:

go test runtime/cgo: open /snap/go/2130/pkg/linux_amd64/runtime/cgo.a: read-only file system
```

Fixes: #504