### PR TITLE
enhanced Go test output (quiet by default, print package path)

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -252,7 +252,17 @@ func (t *TestRunner) runSerialGinkgoSuite() RunResult {
 }
 
 func (t *TestRunner) runGoTestSuite() RunResult {
-	return t.run(t.cmd([]string{"-test.v"}, os.Stdout, 1), nil)
+	args := make([]string, 0)
+	if config.DefaultReporterConfig.Verbose {
+		args = append(args, "-test.v")
+	}
+	result := t.run(t.cmd(args, os.Stdout, 1), nil)
+	keyword := "ok"
+	if !result.Passed {
+		keyword = "FAIL"
+	}
+	fmt.Printf("%s %s\n", keyword, t.Suite.Path)
+	return result
 }
 
 func (t *TestRunner) runAndStreamParallelGinkgoSuite() RunResult {


### PR DESCRIPTION
"ginkgo" can replace "go test" as test runner also for normal Go
tests, but the output was different:
- tests were always run with -test.v and thus produced output
  also on success
- there was no indication of which test produced the output

Now the output behavior is closer to that of "go test":
- tests run in verbose mode only when "ginkgo -v" is used
- after each test, a line with "ok/FAIL <test path>" is
  printed

That line is not quite the same as in "go test", which prints the
import path, but close enough. That line is important when running in
quite mode, because without it one would not be able to tell what
tests were run. Even in verbose mode the output could be
ambiguous (for example, when different packages happen to contain the
same test).

Example:

$ go test ./pkg/log ./pkg/log/testlog
ok  	github.com/foo/bar/pkg/log	0.005s
--- FAIL: TestOutput2 (0.00s)
	testlog_test.go:40: INFO TestOutput2
	testlog_test.go:42: was asked to fail
FAIL
FAIL	github.com/foo/bar/pkg/log/testlog	1.417s

$ ginkgo ./pkg/log ./pkg/log/testlog
PASS
ok ./pkg/log
--- FAIL: TestOutput2 (0.00s)
	testlog_test.go:40: INFO TestOutput2
	testlog_test.go:42: was asked to fail
FAIL
FAIL ./pkg/log/testlog

Ginkgo ran 2 suites in 2.145256459s
Test Suite Failed

Fixes: #508