### PR TITLE
fix running precompiled tests via ginkgo CLI on windows (#529)

### DIFF
--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -425,7 +426,11 @@ func (t *TestRunner) cmd(ginkgoArgs []string, stream io.Writer, node int) *exec.
 
 	path := t.compilationTargetPath
 	if t.Suite.Precompiled {
-		path, _ = filepath.Abs(filepath.Join(t.Suite.Path, fmt.Sprintf("%s.test", t.Suite.PackageName)))
+		windowsExt := ""
+		if runtime.GOOS == "windows" {
+			windowsExt = ".exe"
+		}
+		path, _ = filepath.Abs(filepath.Join(t.Suite.Path, fmt.Sprintf("%s.test%s", t.Suite.PackageName, windowsExt)))
 	}
 
 	cmd := exec.Command(path, args...)


### PR DESCRIPTION
Hello,

Here is a suggested change to support running precompiled tests on windows via ginkgo CLI (see issue #529 for more details).
