### PR TITLE
Ensure generated test file names are underscored

### DIFF
--- a/ginkgo/generate_command.go
+++ b/ginkgo/generate_command.go
@@ -108,10 +108,8 @@ func generateSpec(args []string, agouti, noDot, internal bool) {
 func generateSpecForSubject(subject string, agouti, noDot, internal bool) error {
 	packageName, specFilePrefix, formattedName := getPackageAndFormattedName()
 	if subject != "" {
-		subject = strings.Split(subject, ".go")[0]
-		subject = strings.Split(subject, "_test")[0]
-		specFilePrefix = subject
-		formattedName = prettifyPackageName(subject)
+		specFilePrefix = formatSubject(subject)
+		formattedName = prettifyPackageName(specFilePrefix)
 	}
 
 	data := specData{
@@ -150,6 +148,14 @@ func generateSpecForSubject(subject string, agouti, noDot, internal bool) error 
 	specTemplate.Execute(f, data)
 	goFmt(targetFile)
 	return nil
+}
+
+func formatSubject(name string) string {
+	name = strings.Replace(name, "-", "_", -1)
+	name = strings.Replace(name, " ", "_", -1)
+	name = strings.Split(name, ".go")[0]
+	name = strings.Split(name, "_test")[0]
+	return name
 }
 
 func getPackageImportPath() string {

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -221,6 +221,21 @@ var _ = Describe("Subcommand", func() {
 			})
 		})
 
+		Context("with an argument of the form: foo-test", func() {
+			It("should generate a test file named after the argument", func() {
+				session := startGinkgo(pkgPath, "generate", "baz-buzz-test")
+				Eventually(session).Should(gexec.Exit(0))
+				output := session.Out.Contents()
+
+				Ω(output).Should(ContainSubstring("baz_buzz_test.go"))
+
+				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(content).Should(ContainSubstring("package foo_bar_test"))
+				Ω(content).Should(ContainSubstring(`var _ = Describe("BazBuzz", func() {`))
+			})
+		})
+
 		Context("with an argument of the form: foo_test.go", func() {
 			It("should generate a test file named after the argument", func() {
 				session := startGinkgo(pkgPath, "generate", "baz_buzz_test.go")


### PR DESCRIPTION
Have you ever started a new project and then experienced the following sadness?

```sh
$ ginkgo bootstrap
Generating ginkgo test suite bootstrap for foo in:
	foo_suite_test.go

$ ginkgo generate bar-baz
Generating ginkgo test for BarBaz in:
  bar-baz_test.go

$ ls
bar-baz_test.go   foo_suite_test.go
$ :(
```

This PR ensures that no matter how lazy you are when it comes to typing underscores, your filenames are formatted to a nice and consistent standard.