### PR TITLE
Discard exported method declaration when running ginkgo bootstrap

### DIFF
--- a/ginkgo/nodot/nodot.go
+++ b/ginkgo/nodot/nodot.go
@@ -186,7 +186,9 @@ func getExportedDeclarationsForFile(path string) ([]string, error) {
 				declarations = append(declarations, s.Names[0].Name)
 			}
 		case *ast.FuncDecl:
-			declarations = append(declarations, x.Name.Name)
+			if x.Recv == nil {
+				declarations = append(declarations, x.Name.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, ginkgo bootstrap -nodot will make compile error because
it export function including method. Fix it by ignore FuncDecl if
Recv is not nil.

Fixes #557