### PR TITLE
allow config of the vet flag for `go test`

### DIFF
--- a/ginkgo/run_watch_and_build_command_flags.go
+++ b/ginkgo/run_watch_and_build_command_flags.go
@@ -140,6 +140,7 @@ func (c *RunWatchAndBuildCommandFlags) flags(mode int) {
 	c.FlagSet.IntVar(c.intSlot("memprofilerate"), "memprofilerate", 0, "Enable more precise (and expensive) memory profiles by setting runtime.MemProfileRate.")
 	c.FlagSet.StringVar(c.stringSlot("outputdir"), "outputdir", "", "Place output files from profiling in the specified directory.")
 	c.FlagSet.BoolVar(c.boolSlot("requireSuite"), "requireSuite", false, "Fail if there are ginkgo tests in a directory but no test suite (missing RunSpecs)")
+	c.FlagSet.StringVar(c.stringSlot("vet"), "vet", "", "Configure the invocation of 'go vet' to use the comma-separated list of vet checks. If list is 'off', 'go test' does not run 'go vet' at all.")
 
 	if mode == runMode || mode == watchMode {
 		config.Flags(c.FlagSet, "", false)

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -119,6 +119,7 @@ func (t *TestRunner) BuildArgs(path string) []string {
 		"coverpkg",
 		"tags",
 		"gcflags",
+		"vet",
 	}
 
 	for _, opt := range stringOpts {

--- a/ginkgo/testrunner/test_runner_test.go
+++ b/ginkgo/testrunner/test_runner_test.go
@@ -32,6 +32,7 @@ var _ = Describe("TestRunner", func() {
 			"coverpkg":         strAddr(""),
 			"cover":            boolAddr(false),
 			"blockprofilerate": intAddr(100),
+			"vet":              strAddr("off"),
 		}
 		tr := testrunner.New(testsuite.TestSuite{}, 1, false, 0, opts, []string{})
 
@@ -50,6 +51,7 @@ var _ = Describe("TestRunner", func() {
 			"-asmflags=a",
 			"-pkgdir=b",
 			"-gcflags=c",
+			"-vet=off",
 		}))
 	})
 })


### PR DESCRIPTION
This is useful when running ginkgo against go code built pre-`1.11`, when vet wasn't run by default by `go test`