### PR TITLE
Support testing projects using go modules with vendor directories

### DIFF
--- a/ginkgo/run_watch_and_build_command_flags.go
+++ b/ginkgo/run_watch_and_build_command_flags.go
@@ -126,6 +126,7 @@ func (c *RunWatchAndBuildCommandFlags) flags(mode int) {
 	c.FlagSet.BoolVar(c.boolSlot("work"), "work", false, "Print the name of the temporary work directory and do not delete it when exiting.")
 	c.FlagSet.StringVar(c.stringSlot("asmflags"), "asmflags", "", "Arguments to pass on each go tool asm invocation.")
 	c.FlagSet.StringVar(c.stringSlot("buildmode"), "buildmode", "", "Build mode to use. See 'go help buildmode' for more.")
+	c.FlagSet.StringVar(c.stringSlot("mod"), "mod", "", "Go module control. See 'go help modules' for more.")
 	c.FlagSet.StringVar(c.stringSlot("compiler"), "compiler", "", "Name of compiler to use, as in runtime.Compiler (gccgo or gc).")
 	c.FlagSet.StringVar(c.stringSlot("gccgoflags"), "gccgoflags", "", "Arguments to pass on each gccgo compiler/linker invocation.")
 	c.FlagSet.StringVar(c.stringSlot("installsuffix"), "installsuffix", "", "A suffix to use in the name of the package installation directory.")

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -119,6 +119,7 @@ func (t *TestRunner) BuildArgs(path string) []string {
 		"coverpkg",
 		"tags",
 		"gcflags",
+		"mod",
 	}
 
 	for _, opt := range stringOpts {

--- a/ginkgo/testrunner/test_runner_test.go
+++ b/ginkgo/testrunner/test_runner_test.go
@@ -32,6 +32,7 @@ var _ = Describe("TestRunner", func() {
 			"coverpkg":         strAddr(""),
 			"cover":            boolAddr(false),
 			"blockprofilerate": intAddr(100),
+			"mod":              strAddr("vendor"),
 		}
 		tr := testrunner.New(testsuite.TestSuite{}, 1, false, 0, opts, []string{})
 
@@ -50,6 +51,7 @@ var _ = Describe("TestRunner", func() {
 			"-asmflags=a",
 			"-pkgdir=b",
 			"-gcflags=c",
+			"-mod=vendor",
 		}))
 	})
 })


### PR DESCRIPTION
Currently when testing a project using a vendor directory and go modules, I see that ginkgo is unaware of the `-mod` compilation flag given to the go binary. Since it is never given, dependencies are always pulled instead of being found in vendor/.

This change will pass a `-mod` flag through to the go build command.