### PR TITLE
Print help to stdout when the user asks for help

### DIFF
--- a/ginkgo/main.go
+++ b/ginkgo/main.go
@@ -153,6 +153,7 @@ func (c *Command) Matches(name string) bool {
 }
 
 func (c *Command) Run(args []string, additionalArgs []string) {
+	c.FlagSet.Usage = usage
 	c.FlagSet.Parse(args)
 	c.Command(c.FlagSet.Args(), additionalArgs)
 }
@@ -215,20 +216,21 @@ func commandMatching(name string) (*Command, bool) {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Ginkgo Version %s\n\n", config.VERSION)
+	fmt.Printf("Ginkgo Version %s\n\n", config.VERSION)
 	usageForCommand(DefaultCommand, false)
 	for _, command := range Commands {
-		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Printf("\n")
 		usageForCommand(command, false)
 	}
 }
 
 func usageForCommand(command *Command, longForm bool) {
-	fmt.Fprintf(os.Stderr, "%s\n%s\n", command.UsageCommand, strings.Repeat("-", len(command.UsageCommand)))
-	fmt.Fprintf(os.Stderr, "%s\n", strings.Join(command.Usage, "\n"))
+	fmt.Printf("%s\n%s\n", command.UsageCommand, strings.Repeat("-", len(command.UsageCommand)))
+	fmt.Printf("%s\n", strings.Join(command.Usage, "\n"))
 	if command.SuppressFlagDocumentation && !longForm {
-		fmt.Fprintf(os.Stderr, "%s\n", strings.Join(command.FlagDocSubstitute, "\n  "))
+		fmt.Printf("%s\n", strings.Join(command.FlagDocSubstitute, "\n  "))
 	} else {
+		command.FlagSet.SetOutput(os.Stdout)
 		command.FlagSet.PrintDefaults()
 	}
 }

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -421,7 +421,7 @@ var _ = Describe("Subcommand", func() {
 		It("should print out usage information", func() {
 			session := startGinkgo("", "help")
 			Eventually(session).Should(gexec.Exit(0))
-			output := string(session.Err.Contents())
+			output := string(session.Out.Contents())
 
 			Ω(output).Should(MatchRegexp(`Ginkgo Version \d+\.\d+\.\d+`))
 			Ω(output).Should(ContainSubstring("ginkgo watch"))


### PR DESCRIPTION
This changes behaviour of `ginkgo -h`. Before this PR, it used to print a different usage from what `ginkgo help` prints. This is caused by go's inbuilt flag library choosing the print the `defaultUsage` when the `Usage` func is not defined on a `flagSet`.

Another thing to note is `ginkgo -h` exits with exit code 2, `ginkgo help` exits with 0. This is consistent with previous behaviour. Ideally we should change `ginkgo -h` to exit with 0, but it is currently hard-coded in the flag library.

PS: `ginkgo --help` behaves exactly the same as `ginkgo -h`.

[Fixes #567]