### PR TITLE
Add support for go module when running `generate` command

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -12,12 +12,12 @@ SuiteSummary represents the a summary of the test suite and is passed to both
 Reporter.SpecSuiteWillBegin
 Reporter.SpecSuiteDidEnd
 
-this is unfortunate as these two methods should receive different objects.  When running in parallel
+this is unfortunate as these two methods should receive different objects. When running in parallel
 each node does not deterministically know how many specs it will end up running.
 
 Unfortunately making such a change would break backward compatibility.
 
-Until Ginkgo 2.0 comes out we will continue to reuse this struct but populate unkown fields
+Until Ginkgo 2.0 comes out we will continue to reuse this struct but populate unknown fields
 with -1.
 */
 type SuiteSummary struct {


### PR DESCRIPTION
Add support for go module when running `generate` command
Typo fix

This changes how `generate` command looks for import path. Now it will
try to find `go.mod` file and determine import path from there first,
and will fallback to old way otherwise.

Ref:
Two functions I used are from original go source code:
* [findModuleRoot](https://github.com/golang/go/blob/master/src/cmd/go/internal/modload/init.go#L480)
* [moduleName ~ slightly modified of ModulePath](https://github.com/golang/go/blob/master/src/cmd/go/internal/modfile/read.go#L837)

[Fixes #524]