### PR TITLE
Simplify code

### DIFF
--- a/ginkgo/bootstrap_command.go
+++ b/ginkgo/bootstrap_command.go
@@ -131,10 +131,7 @@ func determinePackageName(name string, internal bool) string {
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }
 
 func generateBootstrap(agouti, noDot, internal bool, customBootstrapFile string) {

--- a/ginkgo/convert/import.go
+++ b/ginkgo/convert/import.go
@@ -1,7 +1,6 @@
 package convert
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 )
@@ -24,7 +23,7 @@ func importsForRootNode(rootNode *ast.File) (imports *ast.GenDecl, err error) {
 		}
 	}
 
-	err = errors.New(fmt.Sprintf("Could not find imports for root node:\n\t%#v\n", rootNode))
+	err = fmt.Errorf("Could not find imports for root node:\n\t%#v\n", rootNode)
 	return
 }
 

--- a/ginkgo/convert/package_rewriter.go
+++ b/ginkgo/convert/package_rewriter.go
@@ -24,7 +24,6 @@ func RewritePackage(packageName string) {
 	for _, filename := range findTestsInPackage(pkg) {
 		rewriteTestsInFile(filename)
 	}
-	return
 }
 
 /*

--- a/ginkgo/convert/testfile_rewriter.go
+++ b/ginkgo/convert/testfile_rewriter.go
@@ -61,7 +61,6 @@ func rewriteTestsInFile(pathToFile string) {
 	}
 
 	ioutil.WriteFile(pathToFile, buffer.Bytes(), fileInfo.Mode())
-	return
 }
 
 /*
@@ -88,7 +87,6 @@ func rewriteTestFuncAsItStatement(testFunc *ast.FuncDecl, rootNode *ast.File, de
 
 	// remove the old test func from the root node's declarations
 	rootNode.Decls = append(rootNode.Decls[:funcIndex], rootNode.Decls[funcIndex+1:]...)
-	return
 }
 
 /*

--- a/ginkgo/interrupthandler/interrupt_handler.go
+++ b/ginkgo/interrupthandler/interrupt_handler.go
@@ -16,7 +16,7 @@ type InterruptHandler struct {
 func NewInterruptHandler() *InterruptHandler {
 	h := &InterruptHandler{
 		lock: &sync.Mutex{},
-		C:    make(chan bool, 0),
+		C:    make(chan bool),
 	}
 
 	go h.handleInterrupt()

--- a/ginkgo/suite_runner.go
+++ b/ginkgo/suite_runner.go
@@ -41,7 +41,7 @@ func (r *SuiteRunner) compileInParallel(runners []*testrunner.TestRunner, numCom
 	//an array of channels - the nth runner's compilation output is sent to the nth channel in this array
 	//we read from these channels in order to ensure we run the suites in order
 	orderedCompilationOutputs := []chan compilationOutput{}
-	for _ = range runners {
+	for range runners {
 		orderedCompilationOutputs = append(orderedCompilationOutputs, make(chan compilationOutput, 1))
 	}
 

--- a/ginkgo/testrunner/test_runner.go
+++ b/ginkgo/testrunner/test_runner.go
@@ -156,7 +156,7 @@ func (t *TestRunner) CompileTo(path string) error {
 		fmt.Println(string(output))
 	}
 
-	if fileExists(path) == false {
+	if !fileExists(path) {
 		compiledFile := t.Suite.PackageName + ".test"
 		if fileExists(compiledFile) {
 			// seems like we are on an old go version that does not support the -o flag on go test
@@ -182,7 +182,7 @@ func (t *TestRunner) CompileTo(path string) error {
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
-	return err == nil || os.IsNotExist(err) == false
+	return err == nil || !os.IsNotExist(err)
 }
 
 // copyFile copies the contents of the file named src to the file named

--- a/ginkgo/watch/dependencies.go
+++ b/ginkgo/watch/dependencies.go
@@ -77,7 +77,7 @@ func (d Dependencies) resolveAndAdd(deps []string, depth int) {
 		if err != nil {
 			continue
 		}
-		if pkg.Goroot == false && !ginkgoAndGomegaFilter.Match([]byte(pkg.Dir)) {
+		if !pkg.Goroot && !ginkgoAndGomegaFilter.Match([]byte(pkg.Dir)) {
 			d.addDepIfNotPresent(pkg.Dir, depth)
 		}
 	}

--- a/ginkgo/watch/package_hash.go
+++ b/ginkgo/watch/package_hash.go
@@ -36,7 +36,7 @@ func (p *PackageHash) CheckForChanges() bool {
 	codeHash, codeModifiedTime, testHash, testModifiedTime, deleted := p.computeHashes()
 
 	if deleted {
-		if p.Deleted == false {
+		if !p.Deleted {
 			t := time.Now()
 			p.CodeModifiedTime = t
 			p.TestModifiedTime = t

--- a/internal/leafnodes/benchmarker.go
+++ b/internal/leafnodes/benchmarker.go
@@ -17,7 +17,7 @@ type benchmarker struct {
 
 func newBenchmarker() *benchmarker {
 	return &benchmarker{
-		measurements: make(map[string]*types.SpecMeasurement, 0),
+		measurements: make(map[string]*types.SpecMeasurement),
 	}
 }
 

--- a/internal/remote/aggregator.go
+++ b/internal/remote/aggregator.go
@@ -54,11 +54,11 @@ func NewAggregator(nodeCount int, result chan bool, config config.DefaultReporte
 		config:       config,
 		stenographer: stenographer,
 
-		suiteBeginnings: make(chan configAndSuite, 0),
-		beforeSuites:    make(chan *types.SetupSummary, 0),
-		afterSuites:     make(chan *types.SetupSummary, 0),
-		specCompletions: make(chan *types.SpecSummary, 0),
-		suiteEndings:    make(chan *types.SuiteSummary, 0),
+		suiteBeginnings: make(chan configAndSuite),
+		beforeSuites:    make(chan *types.SetupSummary),
+		afterSuites:     make(chan *types.SetupSummary),
+		specCompletions: make(chan *types.SpecSummary),
+		suiteEndings:    make(chan *types.SuiteSummary),
 	}
 
 	go aggregator.mux()
@@ -227,7 +227,7 @@ func (aggregator *Aggregator) registerSuiteEnding(suite *types.SuiteSummary) (fi
 	aggregatedSuiteSummary.SuiteSucceeded = true
 
 	for _, suiteSummary := range aggregator.aggregatedSuiteEndings {
-		if suiteSummary.SuiteSucceeded == false {
+		if !suiteSummary.SuiteSucceeded {
 			aggregatedSuiteSummary.SuiteSucceeded = false
 		}
 


### PR DESCRIPTION
- Removed unnecessary returns
- Simpler boolean comparisons
- No need to specify capacity of 0, which is the default
- Use fmt.Errorf