### PR TITLE
stack backtrace: fix skipping

### DIFF
--- a/internal/codelocation/code_location.go
+++ b/internal/codelocation/code_location.go
@@ -11,7 +11,7 @@ import (
 
 func New(skip int) types.CodeLocation {
 	_, file, line, _ := runtime.Caller(skip + 1)
-	stackTrace := PruneStack(string(debug.Stack()), skip)
+	stackTrace := PruneStack(string(debug.Stack()), skip+1)
 	return types.CodeLocation{FileName: file, LineNumber: line, FullStackTrace: stackTrace}
 }
 


### PR DESCRIPTION
The full backtrace included one entry too many. This only mattered
when that entry wasn't in Ginkgo itself, because otherwise pruning
removed it.