### PR TITLE
A new CLI option: -ginkgo.reportFile <file path>

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type DefaultReporterConfigType struct {
 	Verbose           bool
 	FullTrace         bool
 	ReportPassed      bool
+	ReportFile        string
 }
 
 var DefaultReporterConfig = DefaultReporterConfigType{}
@@ -100,6 +101,8 @@ func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
 	flagSet.BoolVar(&(DefaultReporterConfig.Succinct), prefix+"succinct", false, "If set, default reporter prints out a very succinct report")
 	flagSet.BoolVar(&(DefaultReporterConfig.FullTrace), prefix+"trace", false, "If set, default reporter prints out the full stack trace when a failure occurs")
 	flagSet.BoolVar(&(DefaultReporterConfig.ReportPassed), prefix+"reportPassed", false, "If set, default reporter prints out captured output of passed tests.")
+	flagSet.StringVar(&(DefaultReporterConfig.ReportFile), prefix+"reportFile", "", "Override the default reporter output file path.")
+
 }
 
 func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultReporterConfigType) []string {
@@ -200,6 +203,10 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 
 	if reporter.ReportPassed {
 		result = append(result, fmt.Sprintf("--%sreportPassed", prefix))
+	}
+
+	if reporter.ReportFile != "" {
+		result = append(result, fmt.Sprintf("--%sreportFile=%s", prefix, reporter.ReportFile))
 	}
 
 	return result

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -199,6 +199,11 @@ type Benchmarker interface {
 //	ginkgo bootstrap
 func RunSpecs(t GinkgoTestingT, description string) bool {
 	specReporters := []Reporter{buildDefaultReporter()}
+	if config.DefaultReporterConfig.ReportFile != "" {
+		reportFile := config.DefaultReporterConfig.ReportFile
+		specReporters[0] = reporters.NewJUnitReporter(reportFile)
+		return RunSpecsWithDefaultAndCustomReporters(t, description, specReporters)
+	}
 	return RunSpecsWithCustomReporters(t, description, specReporters)
 }
 

--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/onsi/ginkgo/config"
@@ -141,17 +142,29 @@ func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	reporter.suite.Time = math.Trunc(summary.RunTime.Seconds()*1000) / 1000
 	reporter.suite.Failures = summary.NumberOfFailedSpecs
 	reporter.suite.Errors = 0
-	file, err := os.Create(reporter.filename)
+	if reporter.ReporterConfig.ReportFile != "" {
+		reporter.filename = reporter.ReporterConfig.ReportFile
+		fmt.Printf("\nJUnit path was configured: %s\n", reporter.filename)
+	}
+	filePath, _ := filepath.Abs(reporter.filename)
+	dirPath := filepath.Dir(filePath)
+	err := os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create JUnit report file: %s\n\t%s", reporter.filename, err.Error())
+		fmt.Printf("\nFailed to create JUnit directory: %s\n\t%s", filePath, err.Error())
+	}
+	file, err := os.Create(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create JUnit report file: %s\n\t%s", filePath, err.Error())
 	}
 	defer file.Close()
 	file.WriteString(xml.Header)
 	encoder := xml.NewEncoder(file)
 	encoder.Indent("  ", "    ")
 	err = encoder.Encode(reporter.suite)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to generate JUnit report\n\t%s", err.Error())
+	if err == nil {
+		fmt.Fprintf(os.Stdout, "\nJUnit report was created: %s\n", filePath)
+	} else {
+		fmt.Fprintf(os.Stderr,"\nFailed to generate JUnit report data:\n\t%s", err.Error())
 	}
 }
 


### PR DESCRIPTION
If specified, it will change the Junit output file path,
that was pre-configured in ginkgo test suite.
It will create parent directories, if not already exist.

Use this option in order to avoid modifying and building
the suite test files, just to specify new report file path.

For example, when running with:
`--reportFile ../../a_new_dir_1/a_new_dir_2/junit.xml`

The junit.xml report will be created under:
`<current path>../../a_new_dir_1/a_new_dir_2/`

Note the changes in RunSpecs() of ginkgo_dsl.go:
It will create a new Junit file, even if Junit report
was not predefined in the test suites. I.e.:
When using this CLI option, there's no longer need to call:
```
reporterList := []ginkgo.Reporter{}
reporterList = append(reporterList, reporters.NewJUnitReporter(junitPath))
ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Test suite", reporterList)
```

[Fixes onsi#320]