### PR TITLE
speed up table entry generateIt()

### DIFF
--- a/extensions/table/table_entry.go
+++ b/extensions/table/table_entry.go
@@ -23,7 +23,7 @@ func (t TableEntry) generateIt(itBody reflect.Value) {
 	}
 
 	values := make([]reflect.Value, len(t.Parameters))
-	var iBodyType = itBody.Type()
+	iBodyType := itBody.Type()
 	for i, param := range t.Parameters {
 		if param == nil {
 			inType := iBodyType.In(i)

--- a/extensions/table/table_entry.go
+++ b/extensions/table/table_entry.go
@@ -22,18 +22,15 @@ func (t TableEntry) generateIt(itBody reflect.Value) {
 		return
 	}
 
-	values := []reflect.Value{}
+	values := make([]reflect.Value, len(t.Parameters))
+	var iBodyType = itBody.Type()
 	for i, param := range t.Parameters {
-		var value reflect.Value
-
 		if param == nil {
-			inType := itBody.Type().In(i)
-			value = reflect.Zero(inType)
+			inType := iBodyType.In(i)
+			values[i] = reflect.Zero(inType)
 		} else {
-			value = reflect.ValueOf(param)
+			values[i] = reflect.ValueOf(param)
 		}
-
-		values = append(values, value)
 	}
 
 	body := func() {


### PR DESCRIPTION
speed up the func generateIt() when using table driven tests.
Fix issue(https://github.com/onsi/ginkgo/issues/608)