### PR TITLE
feat: table tests should point to test code

### DIFF
--- a/extensions/table/table.go
+++ b/extensions/table/table.go
@@ -13,6 +13,8 @@ import (
 	"reflect"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/types"
 )
 
 /*
@@ -42,7 +44,7 @@ It's important to understand that the `Describe`s and `It`s are generated at eva
 Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
 */
 func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
-	describeTable(description, itBody, entries, false, false)
+	describeTable(description, itBody, entries, types.FlagTypeNone)
 	return true
 }
 
@@ -50,7 +52,7 @@ func DescribeTable(description string, itBody interface{}, entries ...TableEntry
 You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
 */
 func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
-	describeTable(description, itBody, entries, false, true)
+	describeTable(description, itBody, entries, types.FlagTypeFocused)
 	return true
 }
 
@@ -58,7 +60,7 @@ func FDescribeTable(description string, itBody interface{}, entries ...TableEntr
 You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
 */
 func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
-	describeTable(description, itBody, entries, true, false)
+	describeTable(description, itBody, entries, types.FlagTypePending)
 	return true
 }
 
@@ -66,33 +68,19 @@ func PDescribeTable(description string, itBody interface{}, entries ...TableEntr
 You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
 */
 func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
-	describeTable(description, itBody, entries, true, false)
+	describeTable(description, itBody, entries, types.FlagTypePending)
 	return true
 }
 
-func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+func describeTable(description string, itBody interface{}, entries []TableEntry, flag types.FlagType) {
 	itBodyValue := reflect.ValueOf(itBody)
 	if itBodyValue.Kind() != reflect.Func {
 		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
 	}
 
-	if pending {
-		ginkgo.PDescribe(description, func() {
-			for _, entry := range entries {
-				entry.generateIt(itBodyValue)
-			}
-		})
-	} else if focused {
-		ginkgo.FDescribe(description, func() {
-			for _, entry := range entries {
-				entry.generateIt(itBodyValue)
-			}
-		})
-	} else {
-		ginkgo.Describe(description, func() {
-			for _, entry := range entries {
-				entry.generateIt(itBodyValue)
-			}
-		})
-	}
+	ginkgo.ExplicitContainerNode(description, func() {
+		for _, entry := range entries {
+			entry.generateIt(itBodyValue)
+		}
+	}, flag, codelocation.New(2))
 }

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -615,6 +615,22 @@ func AfterEach(body interface{}, timeout ...float64) bool {
 	return true
 }
 
+//ExplicitItNode adds a fully-specified It node to the global context.  This function is largely only
+//useful for meta-programming or adding on to the Ginkgo DSL, when writing normal test cases it's best
+//to use one of the others.
+func ExplicitItNode(text string, body interface{}, flag types.FlagType, codeLocation types.CodeLocation, timeout time.Duration) bool {
+	globalSuite.PushItNode(text, body, flag, codeLocation, timeout)
+	return true
+}
+
+//ExplicitContainerNode adds a fully-specified Container node to the global context.  This function is
+//largely only useful for meta-programming or adding on to the Ginkgo DSL, when writing normal test
+//cases it's best to use one of the others.
+func ExplicitContainerNode(text string, body func(), flag types.FlagType, codeLocation types.CodeLocation) bool {
+	globalSuite.PushContainerNode(text, body, flag, codeLocation)
+	return true
+}
+
 func parseTimeout(timeout ...float64) time.Duration {
 	if len(timeout) == 0 {
 		return time.Duration(defaultTimeout * int64(time.Second))

--- a/integration/_fixtures/failing_table_tests/failing_table_tests_suite_test.go
+++ b/integration/_fixtures/failing_table_tests/failing_table_tests_suite_test.go
@@ -1,0 +1,13 @@
+package failing_table_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestFocused_fixture(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Failing_table_tests Suite")
+}

--- a/integration/_fixtures/failing_table_tests/failing_table_tests_test.go
+++ b/integration/_fixtures/failing_table_tests/failing_table_tests_test.go
@@ -1,0 +1,16 @@
+package failing_table_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FailingTableTests", func() {
+
+	DescribeTable("a failing entry",
+		func(val bool) { Ω(val).Should(BeTrue()) },
+		Entry("passing", true),
+		Entry("failing", false),
+	)
+})

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Running Specs", func() {
 			copyIn(fixturePath("failing_table_tests"), pathToTest, false)
 		})
 
-		FIt("should identify the failing entry", func() {
+		It("should identify the failing entry", func() {
 			session := startGinkgo(pathToTest, "--noColor")
 			Eventually(session).Should(gexec.Exit(1))
 			output := string(session.Out.Contents())


### PR DESCRIPTION
Previously, ginkgo would identify the code locations of the failing
Entry or DescribeTable as part of the
ginkgo/extensions/table/table_entry.go or
ginkgo/extensions/table/table.go files, respectively.

When there are a large number of table entries, it is more desirable to
provide the line numbers of the table and table entry directly to
facilitate jumping to the relevant section of the test code.

Fixes #515