### PR TITLE
Fix missing newline in combined coverage file

### DIFF
--- a/ginkgo/run_command.go
+++ b/ginkgo/run_command.go
@@ -179,18 +179,23 @@ func (r *SpecRunner) combineCoverprofiles(runners []*testrunner.TestRunner) erro
 	for index, runner := range runners {
 		contents, err := ioutil.ReadFile(runner.CoverageFile)
 
+		if err != nil {
+			fmt.Printf("Unable to read coverage file %s to combine, %v\n", runner.CoverageFile, err)
+			return nil // non-fatal error
+		}
+
 		// remove the cover mode line from every file
 		// except the first one
 		if index > 0 {
 			contents = modeRegex.ReplaceAll(contents, []byte{})
 		}
 
-		if err != nil {
-			fmt.Printf("Unable to read coverage file %s to combine, %v\n", runner.CoverageFile, err)
-			return nil // non-fatal error
-		}
-
 		_, err = combined.Write(contents)
+
+		// Add a newline to the end of every file if missing.
+		if err == nil && contents[len(contents)-1] != '\n' {
+			_, err = combined.Write([]byte("\n"))
+		}
 
 		if err != nil {
 			fmt.Printf("Unable to append to coverprofile, %v\n", err)


### PR DESCRIPTION
Hi! It is a slight improvement of https://github.com/onsi/ginkgo/pull/552. Sometimes the coverage file has no newline in the end and the combined report is not usable:

```
mode: atomic
...
github.com/flant/shell-operator/test/utils/shell-operator.go:109.99,111.2 1 0
github.com/flant/shell-operator/test/utils/shell-operator.go:113.106,115.2 1 0github.com/flant/shell-operator/test/utils/kind-k8s-cluster.go:16.50,24.16 4 1
github.com/flant/shell-operator/test/utils/kind-k8s-cluster.go:27.2,27.17 1 1
...
```

```
Error: open github.com/flant/shell-operator/test/utils/shell-operator.go:113.106,115.2 1 0github.com/flant/shell-operator/test/utils/kind-k8s-cluster.go:16.50,24.16 4 1: no such file or directory
Usage:
  cc-test-reporter format-coverage [coverage file] [flags]
```

