### PR TITLE
check if a spec is run before returning SpecSummary

### DIFF
--- a/internal/suite/suite.go
+++ b/internal/suite/suite.go
@@ -102,6 +102,9 @@ func (suite *Suite) generateSpecsIterator(description string, config config.Gink
 }
 
 func (suite *Suite) CurrentRunningSpecSummary() (*types.SpecSummary, bool) {
+	if !suite.running {
+		return nil, false
+	}
 	return suite.runner.CurrentSpecSummary()
 }
 


### PR DESCRIPTION
This pull prevents a null pointer exception by checking if a spec is run before returning its summary. 

The issue might occur when someone simply executes `ginkgo.CurrentGinkgoTestDescription()`