### PR TITLE
fix typo succesful -> successful

### DIFF
--- a/internal/leafnodes/shared_runner_test.go
+++ b/internal/leafnodes/shared_runner_test.go
@@ -47,7 +47,7 @@ func SynchronousSharedRunnerBehaviors(build func(body interface{}, timeout time.
 				}, 0, failer, componentCodeLocation).Run()
 			})
 
-			It("should have a succesful outcome", func() {
+			It("should have a successful outcome", func() {
 				Ω(didRun).Should(BeTrue())
 
 				Ω(outcome).Should(Equal(types.SpecStatePassed))
@@ -166,7 +166,7 @@ func AsynchronousSharedRunnerBehaviors(build func(body interface{}, timeout time
 				}, timeoutDuration, failer, componentCodeLocation).Run()
 			})
 
-			It("should have a succesful outcome", func() {
+			It("should have a successful outcome", func() {
 				Ω(didRun).Should(BeTrue())
 				Ω(outcome).Should(Equal(types.SpecStatePassed))
 				Ω(failure).Should(BeZero())

--- a/internal/remote/aggregator.go
+++ b/internal/remote/aggregator.go
@@ -197,11 +197,11 @@ func (aggregator *Aggregator) announceSpec(specSummary *types.SpecSummary) {
 	switch specSummary.State {
 	case types.SpecStatePassed:
 		if specSummary.IsMeasurement {
-			aggregator.stenographer.AnnounceSuccesfulMeasurement(specSummary, aggregator.config.Succinct)
+			aggregator.stenographer.AnnounceSuccessfulMeasurement(specSummary, aggregator.config.Succinct)
 		} else if specSummary.RunTime.Seconds() >= aggregator.config.SlowSpecThreshold {
-			aggregator.stenographer.AnnounceSuccesfulSlowSpec(specSummary, aggregator.config.Succinct)
+			aggregator.stenographer.AnnounceSuccessfulSlowSpec(specSummary, aggregator.config.Succinct)
 		} else {
-			aggregator.stenographer.AnnounceSuccesfulSpec(specSummary)
+			aggregator.stenographer.AnnounceSuccessfulSpec(specSummary)
 		}
 
 	case types.SpecStatePending:

--- a/internal/remote/aggregator_test.go
+++ b/internal/remote/aggregator_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Aggregator", func() {
 				It("should announce the specs, the before suites and the after suites", func() {
 					Eventually(func() interface{} {
 						return stenographer.Calls()
-					}).Should(ContainElement(call("AnnounceSuccesfulSpec", specSummary)))
+					}).Should(ContainElement(call("AnnounceSuccessfulSpec", specSummary)))
 
 					Ω(stenographer.Calls()).Should(ContainElement(call("AnnounceCapturedOutput", beforeSummary.CapturedOutput)))
 					Ω(stenographer.Calls()).Should(ContainElement(call("AnnounceCapturedOutput", afterSummary.CapturedOutput)))
@@ -197,7 +197,7 @@ var _ = Describe("Aggregator", func() {
 				})
 
 				It("should announce completion", func() {
-					Ω(stenographer.Calls()[3]).Should(Equal(call("AnnounceSuccesfulSpec", specSummary)))
+					Ω(stenographer.Calls()[3]).Should(Equal(call("AnnounceSuccessfulSpec", specSummary)))
 				})
 
 				It("should announce the captured output of the AfterSuite", func() {

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -57,11 +57,11 @@ func (reporter *DefaultReporter) SpecDidComplete(specSummary *types.SpecSummary)
 	switch specSummary.State {
 	case types.SpecStatePassed:
 		if specSummary.IsMeasurement {
-			reporter.stenographer.AnnounceSuccesfulMeasurement(specSummary, reporter.config.Succinct)
+			reporter.stenographer.AnnounceSuccessfulMeasurement(specSummary, reporter.config.Succinct)
 		} else if specSummary.RunTime.Seconds() >= reporter.config.SlowSpecThreshold {
-			reporter.stenographer.AnnounceSuccesfulSlowSpec(specSummary, reporter.config.Succinct)
+			reporter.stenographer.AnnounceSuccessfulSlowSpec(specSummary, reporter.config.Succinct)
 		} else {
-			reporter.stenographer.AnnounceSuccesfulSpec(specSummary)
+			reporter.stenographer.AnnounceSuccessfulSpec(specSummary)
 			if reporter.config.ReportPassed {
 				reporter.stenographer.AnnounceCapturedOutput(specSummary.CapturedOutput)
 			}

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -221,7 +221,7 @@ var _ = Describe("DefaultReporter", func() {
 				})
 
 				It("should announce the measurement", func() {
-					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccesfulMeasurement", spec, false)))
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccessfulMeasurement", spec, false)))
 				})
 			})
 
@@ -231,13 +231,13 @@ var _ = Describe("DefaultReporter", func() {
 				})
 
 				It("should announce that it was slow", func() {
-					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccesfulSlowSpec", spec, false)))
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccessfulSlowSpec", spec, false)))
 				})
 			})
 
 			Context("When the spec is successful", func() {
 				It("should announce the successful spec", func() {
-					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccesfulSpec", spec)))
+					Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccessfulSpec", spec)))
 				})
 
 				Context("When ReportPassed flag is set", func() {
@@ -357,7 +357,7 @@ var _ = Describe("DefaultReporter", func() {
 					})
 
 					It("should announce the measurement", func() {
-						Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccesfulMeasurement", spec, true)))
+						Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccessfulMeasurement", spec, true)))
 					})
 				})
 
@@ -367,13 +367,13 @@ var _ = Describe("DefaultReporter", func() {
 					})
 
 					It("should announce that it was slow", func() {
-						Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccesfulSlowSpec", spec, true)))
+						Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccessfulSlowSpec", spec, true)))
 					})
 				})
 
 				Context("When the spec is successful", func() {
 					It("should announce the successful spec", func() {
-						Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccesfulSpec", spec)))
+						Ω(stenographer.Calls()[0]).Should(Equal(call("AnnounceSuccessfulSpec", spec)))
 					})
 
 					Context("When ReportPassed flag is set", func() {

--- a/reporters/stenographer/fake_stenographer.go
+++ b/reporters/stenographer/fake_stenographer.go
@@ -105,16 +105,16 @@ func (stenographer *FakeStenographer) AnnounceCapturedOutput(output string) {
 	stenographer.registerCall("AnnounceCapturedOutput", output)
 }
 
-func (stenographer *FakeStenographer) AnnounceSuccesfulSpec(spec *types.SpecSummary) {
-	stenographer.registerCall("AnnounceSuccesfulSpec", spec)
+func (stenographer *FakeStenographer) AnnounceSuccessfulSpec(spec *types.SpecSummary) {
+	stenographer.registerCall("AnnounceSuccessfulSpec", spec)
 }
 
-func (stenographer *FakeStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool) {
-	stenographer.registerCall("AnnounceSuccesfulSlowSpec", spec, succinct)
+func (stenographer *FakeStenographer) AnnounceSuccessfulSlowSpec(spec *types.SpecSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSuccessfulSlowSpec", spec, succinct)
 }
 
-func (stenographer *FakeStenographer) AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool) {
-	stenographer.registerCall("AnnounceSuccesfulMeasurement", spec, succinct)
+func (stenographer *FakeStenographer) AnnounceSuccessfulMeasurement(spec *types.SpecSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSuccessfulMeasurement", spec, succinct)
 }
 
 func (stenographer *FakeStenographer) AnnouncePendingSpec(spec *types.SpecSummary, noisy bool) {

--- a/reporters/stenographer/stenographer.go
+++ b/reporters/stenographer/stenographer.go
@@ -47,9 +47,9 @@ type Stenographer interface {
 
 	AnnounceCapturedOutput(output string)
 
-	AnnounceSuccesfulSpec(spec *types.SpecSummary)
-	AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool)
-	AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool)
+	AnnounceSuccessfulSpec(spec *types.SpecSummary)
+	AnnounceSuccessfulSlowSpec(spec *types.SpecSummary, succinct bool)
+	AnnounceSuccessfulMeasurement(spec *types.SpecSummary, succinct bool)
 
 	AnnouncePendingSpec(spec *types.SpecSummary, noisy bool)
 	AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool)
@@ -245,12 +245,12 @@ func (s *consoleStenographer) AnnounceCapturedOutput(output string) {
 	s.midBlock()
 }
 
-func (s *consoleStenographer) AnnounceSuccesfulSpec(spec *types.SpecSummary) {
+func (s *consoleStenographer) AnnounceSuccessfulSpec(spec *types.SpecSummary) {
 	s.print(0, s.colorize(greenColor, s.denoter))
 	s.stream()
 }
 
-func (s *consoleStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool) {
+func (s *consoleStenographer) AnnounceSuccessfulSlowSpec(spec *types.SpecSummary, succinct bool) {
 	s.printBlockWithMessage(
 		s.colorize(greenColor, "%s [SLOW TEST:%.3f seconds]", s.denoter, spec.RunTime.Seconds()),
 		"",
@@ -259,7 +259,7 @@ func (s *consoleStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary,
 	)
 }
 
-func (s *consoleStenographer) AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool) {
+func (s *consoleStenographer) AnnounceSuccessfulMeasurement(spec *types.SpecSummary, succinct bool) {
 	s.printBlockWithMessage(
 		s.colorize(greenColor, "%s [MEASUREMENT]", s.denoter),
 		s.measurementReport(spec, succinct),


### PR DESCRIPTION
Just a little typo across multiple files.

See: 

https://whichiscorrect.com/successful-or-succesful/

and

https://wikidiff.com/succesful/successful