### PR TITLE
Replace tail package with maintained one to fix go get errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/onsi/ginkgo
 
 require (
-	github.com/hpcloud/tail v1.0.0
+	github.com/nxadm/tail v1.4.4
 	github.com/onsi/gomega v1.7.1
 	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
+github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -12,6 +14,7 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/internal/remote/output_interceptor_unix.go
+++ b/internal/remote/output_interceptor_unix.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/hpcloud/tail"
+	"github.com/nxadm/tail"
 	"golang.org/x/sys/unix"
 )
 


### PR DESCRIPTION
The `tail` package depends on an incorrect version of `fsnotify` which causes downloads of the `ginkgo` module to fail with...

```
go: finding module for package github.com/go-fsnotify/fsnotify
go.acme.com/utils tested by
        go.acme.com/utils.test imports
        github.com/onsi/ginkgo imports
        github.com/onsi/ginkgo/internal/remote imports
        github.com/hpcloud/tail imports
        github.com/hpcloud/tail/watch imports
        gopkg.in/fsnotify.v1 tested by
        gopkg.in/fsnotify.v1.test imports
        github.com/go-fsnotify/fsnotify: module github.com/go-fsnotify/fsnotify@latest found (v0.0.0-20180321022601-755488143dae), but does not contain package github.com/go-fsnotify/fsnotify: exit status 1
```

For more info see: https://github.com/hpcloud/tail/issues/168

The author of `tail` has forked it from `HP` and is now maintaining it at https://github.com/nxadm/tail. `HP` is not going to make any updates to the package so it is recommended to replace the module with the maintained one.
