### PR TITLE
Test if a coverprofile content is empty before checking its latest character

### DIFF
--- a/ginkgo/run_command.go
+++ b/ginkgo/run_command.go
@@ -193,7 +193,7 @@ func (r *SpecRunner) combineCoverprofiles(runners []*testrunner.TestRunner) erro
 		_, err = combined.Write(contents)
 
 		// Add a newline to the end of every file if missing.
-		if err == nil && contents[len(contents)-1] != '\n' {
+		if err == nil && len(contents) > 0 && contents[len(contents)-1] != '\n' {
 			_, err = combined.Write([]byte("\n"))
 		}
 


### PR DESCRIPTION
Fix #669 