### PR TITLE
solve the undefined: unix.Dup2 compile error on mips64le

### DIFF
--- a/internal/remote/output_interceptor_darwin.go
+++ b/internal/remote/output_interceptor_darwin.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_dragonfly.go
+++ b/internal/remote/output_interceptor_dragonfly.go
@@ -1,0 +1,11 @@
+// +build dragonfly
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_freebsd.go
+++ b/internal/remote/output_interceptor_freebsd.go
@@ -1,0 +1,11 @@
+// +build freebsd
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_linux.go
+++ b/internal/remote/output_interceptor_linux.go
@@ -1,0 +1,12 @@
+// +build linux
+// +build !mips64le
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_linux_mips64le.go
+++ b/internal/remote/output_interceptor_linux_mips64le.go
@@ -1,0 +1,12 @@
+// +build linux
+// +build mips64le
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup3(oldfd, newfd, 0)
+}

--- a/internal/remote/output_interceptor_netbsd.go
+++ b/internal/remote/output_interceptor_netbsd.go
@@ -1,0 +1,11 @@
+// +build netbsd
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_openbsd.go
+++ b/internal/remote/output_interceptor_openbsd.go
@@ -1,0 +1,11 @@
+// +build openbsd
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_solaris.go
+++ b/internal/remote/output_interceptor_solaris.go
@@ -1,0 +1,11 @@
+// +build solaris
+
+package remote
+
+import (
+        "golang.org/x/sys/unix"
+)
+
+func interceptorDupx(oldfd int, newfd int) {
+	unix.Dup2(oldfd, newfd)
+}

--- a/internal/remote/output_interceptor_unix.go
+++ b/internal/remote/output_interceptor_unix.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/nxadm/tail"
-	"golang.org/x/sys/unix"
 )
 
 func NewOutputInterceptor() OutputInterceptor {
@@ -36,10 +35,8 @@ func (interceptor *outputInterceptor) StartInterceptingOutput() error {
 		return err
 	}
 
-	// This might call Dup3 if the dup2 syscall is not available, e.g. on
-	// linux/arm64 or linux/riscv64
-	unix.Dup2(int(interceptor.redirectFile.Fd()), 1)
-	unix.Dup2(int(interceptor.redirectFile.Fd()), 2)
+	interceptorDupx(int(interceptor.redirectFile.Fd()), 1)
+	interceptorDupx(int(interceptor.redirectFile.Fd()), 2)
 
 	if interceptor.streamTarget != nil {
 		interceptor.tailer, _ = tail.TailFile(interceptor.redirectFile.Name(), tail.Config{Follow: true})


### PR DESCRIPTION
error in detail:
../internal/remote/output_interceptor_unix.go:41:2: undefined: unix.Dup2
../internal/remote/output_interceptor_unix.go:42:2: undefined: unix.Dup2

there is Dup2 syscall only on amd64, other arch is Dup3 instead.

Signed-off-by: Xiaodong Liu <liuxiaodong@loongson.cn>