### PR TITLE
Fix integration tests to stop require GOPATH

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -26,7 +26,7 @@ func TestIntegration(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	pathToGinkgo, err := gexec.Build("github.com/onsi/ginkgo/ginkgo")
+	pathToGinkgo, err := gexec.Build("../ginkgo")
 	Ω(err).ShouldNot(HaveOccurred())
 	return []byte(pathToGinkgo)
 }, func(computedPathToGinkgo []byte) {

--- a/integration/watch_test.go
+++ b/integration/watch_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"go/build"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -41,7 +42,7 @@ var _ = Describe("Watch", func() {
 
 	startGinkgoWithGopath := func(args ...string) *gexec.Session {
 		cmd := ginkgoCommand(rootPath, args...)
-		os.Setenv("GOPATH", rootPath+":"+os.Getenv("GOPATH"))
+		os.Setenv("GOPATH", rootPath+":"+build.Default.GOPATH)
 		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 		Ω(err).ShouldNot(HaveOccurred())
 		return session


### PR DESCRIPTION
This still requires gomega and some version of ginkgo in GOPATH.