### PR TITLE
Add a version of table.Entry that allows dumping the entry parameters.

### DIFF
--- a/extensions/table/table.go
+++ b/extensions/table/table.go
@@ -42,6 +42,25 @@ Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each 
 It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
 
 Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+
+A description function can be passed to Entry in place of the description. The function is then fed with the entry parameters to generate the description of the It corresponding to that particular Entry.
+
+For example:
+
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
 */
 func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
 	describeTable(description, itBody, entries, types.FlagTypeNone)

--- a/extensions/table/table_test.go
+++ b/extensions/table/table_test.go
@@ -1,6 +1,7 @@
 package table_test
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -60,5 +61,55 @@ var _ = Describe("Table", func() {
 			Expect(x).To(BeNil())
 		},
 		Entry("nil", nil),
+	)
+})
+
+var _ = Describe("TableWithParametricDescription", func() {
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
+
+	type ComplicatedThings struct {
+		Superstructure string
+		Substructure   string
+		Count          int
+	}
+
+	describeComplicated := func(desc string) func(ComplicatedThings) string {
+		return func(things ComplicatedThings) string {
+			return fmt.Sprintf("%s things=%v", desc, things)
+		}
+	}
+
+	DescribeTable("a more complicated table",
+		func(c ComplicatedThings) {
+			Ω(strings.Count(c.Superstructure, c.Substructure)).Should(BeNumerically("==", c.Count))
+		},
+		Entry(describeComplicated("with no matching substructures"), ComplicatedThings{
+			Superstructure: "the sixth sheikh's sixth sheep's sick",
+			Substructure:   "emir",
+			Count:          0,
+		}),
+		Entry(describeComplicated("with one matching substructure"), ComplicatedThings{
+			Superstructure: "the sixth sheikh's sixth sheep's sick",
+			Substructure:   "sheep",
+			Count:          1,
+		}),
+		Entry(describeComplicated("with many matching substructures"), ComplicatedThings{
+			Superstructure: "the sixth sheikh's sixth sheep's sick",
+			Substructure:   "si",
+			Count:          3,
+		}),
 	)
 })


### PR DESCRIPTION
Sometimes, it's useful to have the parameters of a given table entry as part of the description of the It counterpart.
To achieve that, we add a new family of Entry constructor that accept a function instead of the description as a string.
That function needs to be implemented by the client of the library, and it's called with the list of arguments and returns a string that will be used as description of the given entry.

This was discussed in https://github.com/onsi/ginkgo/issues/688

I am not totally happy with the naming, but I guess keeping it short-ish has a value here. 