### PR TITLE
Add `ResetGlobal` function

### DIFF
--- a/extensions/globals/globals.go
+++ b/extensions/globals/globals.go
@@ -1,0 +1,26 @@
+// Package `globals` provides an interface to alter the global state of ginkgo suite.
+//
+// ginkgo currently registers a few singleton global vars that hold all the
+// test blocks and failure management. These vars are global per package, which means
+// that only one Suite definition can coexist in one package.
+//
+// However, there can be some use cases where applications using ginkgo may want to
+// have a bit more control about this. For instance, a package may be using ginkgo
+// to dynamically generate different tests and groups depending on some configuration.
+// In this particular case, if the application wants to test how these different groups
+// are generated, they will need access to change these global variables, so they
+// can re-generate this global state, and ensure that different configuration generate
+// indeed different tests.
+//
+// Note that this package is not intended to be used as part of normal ginkgo setups, and
+// usually, you will never need to worry about the global state of ginkgo
+package globals
+
+import "github.com/onsi/ginkgo/internal/global"
+
+// Reset calls `global.InitializeGlobals()` which will basically create a new instance
+// of Suite, and therefore, will effectively reset the global variables to the init state.
+// This will effectively remove all groups, tests and blocks that were added to the Suite.
+func Reset() {
+	global.InitializeGlobals()
+}

--- a/extensions/globals/globals_test.go
+++ b/extensions/globals/globals_test.go
@@ -1,0 +1,43 @@
+package globals_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/globals"
+	. "github.com/onsi/gomega"
+)
+
+func TestGlobals(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	// define some vars to store how many times a test has been run
+	var (
+		testI  = 0
+		testII = 0
+	)
+
+	// Define a simple gingko test I
+	var _ = Describe("ginkgo test I", func() {
+		It("build tests I", func() {
+			testI++
+			Ω(testI).Should(Equal(1))
+		})
+	})
+
+	RunSpecs(t, "Test Runner Suite I")
+
+	// reset the global state of ginkgo. test I should now be removed, and it
+	// won't run twice.
+	globals.Reset()
+
+	// Define a simple gingko test II
+	var _ = Describe("ginkgo test II", func() {
+		It("build tests II", func() {
+			testII++
+			Ω(testII).Should(Equal(1))
+		})
+	})
+
+	RunSpecs(t, "Test Runner Suite II")
+}

--- a/internal/global/init.go
+++ b/internal/global/init.go
@@ -13,6 +13,10 @@ var Suite *suite.Suite
 var Failer *failer.Failer
 
 func init() {
+	InitializeGlobals()
+}
+
+func InitializeGlobals() {
 	Failer = failer.New()
 	Suite = suite.New(Failer)
 }


### PR DESCRIPTION
Hello! First of all, thank you for this amazing project!! ❤️ 

We are currently using Ginkgo to dynamically generate some tests (depending on some configuration) and it works great. However, we are having some troubles to test different scenarios where different `describe` or `context` groups will be created. Since ginkgo stores everything under one global `Suite` struct and there is currently no way to reset that variable, it's very hard for us to test this logic (we are testing the tester, I know! :) 

In this PR, I am adding a `ResetGlobals` function that is exposed as part of the ginkgo DSL, which just resets the globals variables to the original state, and I wanted to get some feedback before spending more time adding tests (I was going to open an Issue first, but given that little amount of code that's needed to show how this could be implemented, I decided to went ahead and open a PR instead, I hope this is ok!)

What do you think about this? Do you think we should do this in a different way? 

Thank you!




 