### PR TITLE
fix junit reporter for parallel testing

### DIFF
--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -191,13 +191,13 @@ type Benchmarker interface {
 //
 //	ginkgo bootstrap
 func RunSpecs(t GinkgoTestingT, description string) bool {
-	specReporters := []Reporter{buildDefaultReporter()}
+	var specReporters []Reporter
+
 	if config.DefaultReporterConfig.ReportFile != "" {
 		reportFile := config.DefaultReporterConfig.ReportFile
-		specReporters[0] = reporters.NewJUnitReporter(reportFile)
-		return RunSpecsWithDefaultAndCustomReporters(t, description, specReporters)
+		specReporters = append(specReporters, reporters.NewJUnitReporter(reportFile))
 	}
-	return RunSpecsWithCustomReporters(t, description, specReporters)
+	return RunSpecsWithDefaultAndCustomReporters(t, description, specReporters)
 }
 
 //To run your tests with Ginkgo's default reporter and your custom reporter(s), replace

--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -155,6 +155,13 @@ func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	if err != nil {
 		fmt.Printf("\nFailed to create JUnit directory: %s\n\t%s", filePath, err.Error())
 	}
+
+	if config.GinkgoConfig.ParallelTotal > 1  {
+		ext := filepath.Ext(filePath)
+		filename := filePath[0:len(filePath)-len(ext)]
+		filePath = fmt.Sprintf("%s_%02d%s", filename, config.GinkgoConfig.ParallelNode, ext)
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create JUnit report file: %s\n\t%s", filePath, err.Error())


### PR DESCRIPTION
When running ginkgo parallel testing with argument `--reportFile`,  junit reporter should contain multiple reporter files, as follows:
```shell
$ ginkgo --reportFile=/tmp/junit.xml  --nodes=4
$ ls /tmp
junit_01.xml junit_02.xml junit_03.xml  junit_04.xml
```