### PR TITLE
create time with precision function

### DIFF
--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -190,6 +190,7 @@ func CurrentGinkgoTestDescription() GinkgoTestDescription {
 //See http://onsi.github.io/ginkgo/#benchmark_tests for more details
 type Benchmarker interface {
 	Time(name string, body func(), info ...interface{}) (elapsedTime time.Duration)
+	TimeWithPrecision(name string, body func(), units string, precision int, info ...interface{}) (elapsedTime time.Duration)
 	RecordValue(name string, value float64, info ...interface{})
 	RecordValueWithPrecision(name string, value float64, units string, precision int, info ...interface{})
 }

--- a/internal/leafnodes/benchmarker.go
+++ b/internal/leafnodes/benchmarker.go
@@ -34,6 +34,19 @@ func (b *benchmarker) Time(name string, body func(), info ...interface{}) (elaps
 	return
 }
 
+func (b *benchmarker) TimeWithPrecision(name string, body func(), units string, precision int, info ...interface{}) (elapsedTime time.Duration) {
+	t := time.Now()
+	body()
+	elapsedTime = time.Since(t)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	measurement := b.getMeasurement(name, "Fastest Time", "Slowest Time", "Average Time", units, precision, info...)
+	measurement.Results = append(measurement.Results, elapsedTime.Seconds())
+
+	return
+}
+
 func (b *benchmarker) RecordValue(name string, value float64, info ...interface{}) {
 	b.mu.Lock()
 	measurement := b.getMeasurement(name, "Smallest", " Largest", " Average", "", 3, info...)


### PR DESCRIPTION
Basic on PR conversation in https://github.com/onsi/ginkgo/pull/266.
It looks like we haven't implement the `TimeWithPrecision ` function for display ms or other unit for
test case report.
<img width="463" alt="Screen Shot 2020-11-02 at 5 24 56 PM" src="https://user-images.githubusercontent.com/62608276/97851453-5bc1df00-1d30-11eb-966f-6ca031a88a64.png">
