### PR TITLE
Print timestamp in By function

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type GinkgoConfigType struct {
 	FailFast           bool
 	FlakeAttempts      int
 	EmitSpecProgress   bool
+	ShowTimestamp      bool
 	DryRun             bool
 	DebugParallel      bool
 
@@ -83,6 +84,8 @@ func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
 	flagSet.IntVar(&(GinkgoConfig.FlakeAttempts), prefix+"flakeAttempts", 1, "Make up to this many attempts to run each spec. Please note that if any of the attempts succeed, the suite will not be failed. But any failures will still be recorded.")
 
 	flagSet.BoolVar(&(GinkgoConfig.EmitSpecProgress), prefix+"progress", false, "If set, ginkgo will emit progress information as each spec runs to the GinkgoWriter.")
+
+	flagSet.BoolVar(&(GinkgoConfig.ShowTimestamp), prefix+"timestamp", false, "If set, ginkgo will print timestamps as each By function executes to the GinkgoWriter.")
 
 	flagSet.BoolVar(&(GinkgoConfig.DebugParallel), prefix+"debug", false, "If set, ginkgo will emit node output to files when running in parallel.")
 
@@ -147,6 +150,10 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 
 	if ginkgo.EmitSpecProgress {
 		result = append(result, fmt.Sprintf("--%sprogress", prefix))
+	}
+
+	if ginkgo.ShowTimestamp {
+		result = append(result, fmt.Sprintf("--%stimestamp", prefix))
 	}
 
 	if ginkgo.DebugParallel {

--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -436,11 +436,15 @@ func XSpecify(text string, is ...interface{}) bool {
 //By allows you to document such flows.  By must be called within a runnable node (It, BeforeEach, Measure, etc...)
 //By will simply log the passed in text to the GinkgoWriter.  If By is handed a function it will immediately run the function.
 func By(text string, callbacks ...func()) {
+	timestamp := ""
+	if config.GinkgoConfig.ShowTimestamp {
+		timestamp = "[" + time.Now().Format(time.RFC3339) + "] "
+	}
 	preamble := "\x1b[1mSTEP\x1b[0m"
 	if config.DefaultReporterConfig.NoColor {
 		preamble = "STEP"
 	}
-	fmt.Fprintln(GinkgoWriter, preamble+": "+text)
+	fmt.Fprintln(GinkgoWriter, timestamp+preamble+": "+text)
 	if len(callbacks) == 1 {
 		callbacks[0]()
 	}


### PR DESCRIPTION
Hi,
I implemented https://github.com/onsi/ginkgo/issues/739 (which was opened by myself). Could you review this PR?

In this PR, I add the `-timestamp` command-line option to ginkgo.
If the `-timestamp` option is specified, ginkgo will output timestamps in each `By` function.

I tried several methods for printing timestamps.
And finally, I concluded printing timestamp in `By` function is good.

I tried the following ways:
- Printing timestamp as spec summary:
  - One look, It's difficult to understand because the `STEP` and the timestamp are divided into two parts.
- Printing timestamp with `-progress` option:
  - It's noisy...
