### PR TITLE
Document the `ginkgo outline` command

### DIFF
--- a/index.md
+++ b/index.md
@@ -1499,6 +1499,34 @@ Also: `ginkgo convert` will **overwrite** your existing test files, so make sure
 
 `ginkgo convert` is the brainchild of [Tim Jarratt](https://github.com/tjarratt)
 
+### Creating an Outline of Tests
+
+If you want to see an outline of the Ginkgo tests in a file, you can use the `ginkgo outline` command. The following uses the `book_test.go` example from [Getting Started: Writing Your First Test](#getting-started-writing-your-first-test):
+
+    ginkgo outline book_test.go
+
+This generates an outline in a comma-separated-values (CSV) format. Column headers are on the first line, followed by Ginkgo containers, specs, and other identifiers, in the order they appear in the file:
+
+    Name,Text,Start,End,Spec,Focused,Pending
+    Describe,Book,124,973,false,false,false
+    BeforeEach,,217,507,false,false,false
+    Describe,Categorizing book length,513,970,false,false,false
+    Context,With more than 300 pages,567,753,false,false,false
+    It,should be a novel,624,742,true,false,false
+    Context,With fewer than 300 pages,763,963,false,false,false
+    It,should be a short story,821,952,true,false,false
+
+The columns are:
+
+- Name (string): The name of a container, spec, or other identifier in the core DSL.
+- Text (string): The description of a container or spec. (If it is not a literal, it is undefined in the outline.)
+- Start (int): Position of the first character in the container or spec.
+- End (int): Position of the character immediately after the container or spec.
+- Spec (bool): True, if the identifier is a spec.
+- Focused (bool): True, if focused. (Conforms to the rules in [Focused Specs](#focused-specs).)
+- Pending (bool): True, if pending. (Conforms to the rules in [Pending Specs](#pending-specs).)
+
+You can set a different output format with the `-format` flag. Accepted formats are `csv`, `indent`, and `json`. The `ident` format is like `csv`, but uses identation to show the nesting of containers and specs. Both the `csv` and `json` formats can be read by another program, e.g., an editor plugin that displays a tree view of Ginkgo tests in a file, or presents a menu for the user to quickly navigate to a container or spec.
 ### Other Subcommands
 
 - To unfocus any programmatically focused tests in the current directory (and subdirectories):


### PR DESCRIPTION
The `ginkgo outline` command was added in https://github.com/onsi/ginkgo/pull/754.