### PR TITLE
Add sidebar link to section on `ginkgo outline` subcommand

### DIFF
--- a/_includes/ginkgo_sidebar.html
+++ b/_includes/ginkgo_sidebar.html
@@ -104,6 +104,9 @@
                 <a href="#converting-existing-tests">Converting Existing Tests</a>
             </li>
             <li>
+                <a href="#creating-an-outline-of-tests">Creating an Outline of Tests</a>
+            </li>
+            <li>
                 <a href="#other-subcommands">Other Subcommands</a>
             </li>
         </ul>


### PR DESCRIPTION
The link was missing from the original document PR (#757).