### PR TITLE
reporters/junit: Use `system-out` element instead of `passed`

### DIFF
--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -33,15 +33,10 @@ type JUnitTestSuite struct {
 type JUnitTestCase struct {
 	Name           string               `xml:"name,attr"`
 	ClassName      string               `xml:"classname,attr"`
-	PassedMessage  *JUnitPassedMessage  `xml:"passed,omitempty"`
 	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
 	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
 	Time           float64              `xml:"time,attr"`
 	SystemOut      string               `xml:"system-out,omitempty"`
-}
-
-type JUnitPassedMessage struct {
-	Message string `xml:",chardata"`
 }
 
 type JUnitFailureMessage struct {
@@ -114,9 +109,7 @@ func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 		ClassName: reporter.testSuiteName,
 	}
 	if reporter.ReporterConfig.ReportPassed && specSummary.State == types.SpecStatePassed {
-		testCase.PassedMessage = &JUnitPassedMessage{
-			Message: specSummary.CapturedOutput,
-		}
+		testCase.SystemOut = specSummary.CapturedOutput
 	}
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
 		testCase.FailureMessage = &JUnitFailureMessage{

--- a/reporters/junit_reporter_test.go
+++ b/reporters/junit_reporter_test.go
@@ -93,7 +93,7 @@ var _ = Describe("JUnit Reporter", func() {
 			Expect(output.TestCases[0].FailureMessage).To(BeNil())
 			Expect(output.TestCases[0].Skipped).To(BeNil())
 			Expect(output.TestCases[0].Time).To(Equal(5.0))
-			Expect(output.TestCases[0].PassedMessage.Message).To(ContainSubstring("Test scenario"))
+			Expect(output.TestCases[0].SystemOut).To(ContainSubstring("Test scenario"))
 		})
 	})
 


### PR DESCRIPTION
Proposed fix for #768.

I would like to hear feedback from JUnit reporter users (or JUnit experts, familiar with the XML schema) before we consider merging this. Thanks!