### PR TITLE
doc: adds a new VSCode extension to provide support for the Ginkgo framework.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Describe("the strings package", func() {
 
 - [Completions for VSCode](https://github.com/onsi/vscode-ginkgo): just use VSCode's extension installer to install `vscode-ginkgo`.
 
+- [Ginkgo tools for VSCode](https://marketplace.visualstudio.com/items?itemName=joselitofilho.ginkgotestexplorer): just use VSCode's extension installer to install `ginkgoTestExplorer`.
+
 - Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](https://onsi.github.io/ginkgo/#third-party-integrations) for details.
 
 - A modular architecture that lets you easily:


### PR DESCRIPTION
I've been working on a VSCode extension to provide support for the Ginkgo framework. You can view the test tree, run/debug them individually, run/debug the entire suite, among other things. For more information visit [here](https://github.com/joselitofilho/ginkgoTestExplorer).

![Ginkgo Test Explorer](https://github.com/joselitofilho/ginkgoTestExplorer/raw/main/media/ginkgotest.gif)

So, I've added this extension on README.md.

**Link to Issue**: #773