### PR TITLE
fix: fixes the test skip when the --focus flag argument contains metacharacters.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"flag"
+	"regexp"
 	"time"
 
 	"fmt"
@@ -139,7 +140,7 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 	}
 
 	for _, s := range ginkgo.FocusStrings {
-		result = append(result, fmt.Sprintf("--%sfocus=%s", prefix, s))
+		result = append(result, fmt.Sprintf("--%sfocus=%s", prefix, regexp.QuoteMeta(s)))
 	}
 
 	for _, s := range ginkgo.SkipStrings {

--- a/integration/_fixtures/flags_tests/flags_test.go
+++ b/integration/_fixtures/flags_tests/flags_test.go
@@ -44,6 +44,12 @@ var _ = Describe("Testing various flags", func() {
 			})
 		})
 
+		Describe("--focus flag argument contains metacharacters", func() {
+			It("should MyMethod() $called", func() {
+				println("MyMethod")
+			})
+		})
+
 		It("should detect races", func(done Done) {
 			var a string
 			go func() {

--- a/integration/flags_test.go
+++ b/integration/flags_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Flags Specs", func() {
 		output := string(session.Out.Contents())
 
 		Ω(output).Should(ContainSubstring("Ran 3 samples:"), "has a measurement")
-		Ω(output).Should(ContainSubstring("11 Passed"))
+		Ω(output).Should(ContainSubstring("12 Passed"))
 		Ω(output).Should(ContainSubstring("0 Failed"))
 		Ω(output).Should(ContainSubstring("1 Pending"))
 		Ω(output).Should(ContainSubstring("3 Skipped"))
@@ -88,7 +88,23 @@ var _ = Describe("Flags Specs", func() {
 		Ω(output).Should(ContainSubstring("3 Passed"))
 		Ω(output).Should(ContainSubstring("0 Failed"))
 		Ω(output).Should(ContainSubstring("0 Pending"))
-		Ω(output).Should(ContainSubstring("12 Skipped"))
+		Ω(output).Should(ContainSubstring("13 Skipped"))
+	})
+
+	It("should override the programmatic focus when the --focus flag argument contains metacharacters", func() {
+		session := startGinkgo(pathToTest, "--noColor", "--focus=should MyMethod() $called")
+		Eventually(session).Should(gexec.Exit(0))
+		output := string(session.Out.Contents())
+
+		Ω(output).Should(ContainSubstring("MyMethod"))
+		Ω(output).Should(ContainSubstring("1 Passed"))
+		Ω(output).Should(ContainSubstring("0 Failed"))
+		Ω(output).Should(ContainSubstring("0 Pending"))
+		Ω(output).Should(ContainSubstring("15 Skipped"))
+	})
+
+	It("should ... when method() ...", func() {
+		Expect(1).To(Equal(1))
 	})
 
 	It("should override the programmatic focus when told to skip", func() {
@@ -99,7 +115,7 @@ var _ = Describe("Flags Specs", func() {
 		Ω(output).ShouldNot(ContainSubstring("marshmallow"))
 		Ω(output).Should(ContainSubstring("chocolate"))
 		Ω(output).Should(ContainSubstring("smores"))
-		Ω(output).Should(ContainSubstring("11 Passed"))
+		Ω(output).Should(ContainSubstring("12 Passed"))
 		Ω(output).Should(ContainSubstring("0 Failed"))
 		Ω(output).Should(ContainSubstring("1 Pending"))
 		Ω(output).Should(ContainSubstring("3 Skipped"))
@@ -113,7 +129,7 @@ var _ = Describe("Flags Specs", func() {
 		Ω(output).ShouldNot(ContainSubstring("marshmallow"))
 		Ω(output).Should(ContainSubstring("chocolate"))
 		Ω(output).Should(ContainSubstring("smores"))
-		Ω(output).Should(ContainSubstring("11 Passed"))
+		Ω(output).Should(ContainSubstring("12 Passed"))
 		Ω(output).Should(ContainSubstring("0 Failed"))
 		Ω(output).Should(ContainSubstring("1 Pending"))
 		Ω(output).Should(ContainSubstring("3 Skipped"))


### PR DESCRIPTION
Fixes #786.