### PR TITLE
Allow Dependabot to manage github-actions 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: daily
     time: '01:00'
   open-pull-requests-limit: 5
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '01:00'
+  open-pull-requests-limit: 5


### PR DESCRIPTION
This PR Allows dependabot to manage github-actions dependencies update.