### PR TITLE
Make it possible to build tests for JS/WASM environments.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,13 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.version }}
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
     - uses: actions/checkout@v2
     - run: go mod tidy && git diff --exit-code go.mod go.sum
     - run: go vet ./...
     - run: go run ./ginkgo -r --randomizeAllSpecs --randomizeSuites --race --trace
+    - run: GOOS=js GOARCH=wasm ginkgo build ./...
+    - run: cp $(shell go env GOROOT)/misc/wasm/wasm_exec.js .
+    - run: find . -name *.test | xargs node ./test.cjs

--- a/internal/remote/output_interceptor_win.go
+++ b/internal/remote/output_interceptor_win.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows js
 
 package remote
 

--- a/test.cjs
+++ b/test.cjs
@@ -1,0 +1,44 @@
+'use strict';
+
+require('./wasm_exec.js');
+var fs = require('fs');
+var path = require('path');
+
+const CWD = process.cwd();
+const EXCLUDES = [
+  "nodot.test",
+  "remote.test",
+  "integration.test"
+];
+
+async function main() {
+  for (let i = 2; i < process.argv.length; i++) {
+    const dirname = path.dirname(path.join(CWD, process.argv[i]))
+    const basename = path.basename(process.argv[i])
+
+    // Skip tests that cannot be executed.
+    if (EXCLUDES.includes(basename)) {
+      continue;
+    }
+
+    // Exit(1) when tests failed.
+    let go = new Go();
+    go.exit = (code) => {
+      if (code !== 0) {
+        process.exit(code);
+      }
+    };
+
+    // Use `chdir` since we are using files based on relative paths in tests.
+    process.chdir(dirname);
+    const mod = await WebAssembly.compile(fs.readFileSync(basename));
+    let inst = await WebAssembly.instantiate(mod, go.importObject);
+
+    await go.run(inst);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Hi,
I'm trying to run tests written using ginkgo in JS/WASM environments. With the current code, we get the following error at build time.

```console
$ GOOS=js GOARCH=wasm ginkgo build ./test/wasm/
Compiling wasm...
Failed to compile wasm:

# github.com/onsi/ginkgo
../../ginkgo/ginkgo_dsl.go:261:108: undefined: remote.NewOutputInterceptor
```

By this PR, I could build my tests. I could also run the test by using the following HTML along with it.
I was wondering if I should split the files because the file names and contents would not match, but once I created this PR. I hope anyone can give me some advice.

```HTML
<!doctype html>
<html lang="en">
<head>
  <title>test colonio</title>
  <meta charset="utf-8">
</head>
<body>
  <!-- copy wasm_exec.js from $(shell go env GOROOT)/misc/wasm/wasm_exec.js -->
  <script src="wasm_exec.js" type="text/javascript"></script>
  <script type="text/javascript">
    const go = new Go();
    // rename output file to `test.wasm`
    WebAssembly.instantiateStreaming(fetch("test.wasm"), go.importObject).then((result) => {
      go.run(result.instance);
    }).catch((err) => {
      console.error(err);
    });
  </script>
</body>
</html>
```

The following is an example of the output from the actual test run.

![image](https://user-images.githubusercontent.com/2675889/129473470-e30bc620-e369-4124-ba99-2306236dbfb2.png)

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>