### PR TITLE
Go 1.17 chores

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.16' ]
+        version: [ '1.16', '1.17' ]
     name: Go ${{ matrix.version }}
     steps:
     - uses: actions/setup-go@v2

--- a/ginkgo/generators/bootstrap_command.go
+++ b/ginkgo/generators/bootstrap_command.go
@@ -3,7 +3,6 @@ package generators
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -86,7 +85,7 @@ func generateBootstrap(conf GeneratorsConfig) {
 
 	var templateText string
 	if conf.CustomTemplate != "" {
-		tpl, err := ioutil.ReadFile(conf.CustomTemplate)
+		tpl, err := os.ReadFile(conf.CustomTemplate)
 		command.AbortIfError("Failed to read custom bootstrap file:", err)
 		templateText = string(tpl)
 	} else if conf.Agouti {

--- a/ginkgo/generators/generate_command.go
+++ b/ginkgo/generators/generate_command.go
@@ -3,7 +3,6 @@ package generators
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -105,7 +104,7 @@ func generateTestFileForSubject(subject string, conf GeneratorsConfig) {
 
 	var templateText string
 	if conf.CustomTemplate != "" {
-		tpl, err := ioutil.ReadFile(conf.CustomTemplate)
+		tpl, err := os.ReadFile(conf.CustomTemplate)
 		command.AbortIfError("Failed to read custom template file:", err)
 		templateText = string(tpl)
 	} else if conf.Agouti {

--- a/ginkgo/internal/profiles_and_reports.go
+++ b/ginkgo/internal/profiles_and_reports.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -159,7 +158,7 @@ func MergeAndCleanupCoverProfiles(profiles []string, destination string) error {
 	combined := &bytes.Buffer{}
 	modeRegex := regexp.MustCompile(`^mode: .*\n`)
 	for i, profile := range profiles {
-		contents, err := ioutil.ReadFile(profile)
+		contents, err := os.ReadFile(profile)
 		if err != nil {
 			return fmt.Errorf("Unable to read coverage file %s:\n%s", profile, err.Error())
 		}
@@ -183,7 +182,7 @@ func MergeAndCleanupCoverProfiles(profiles []string, destination string) error {
 		}
 	}
 
-	err := ioutil.WriteFile(destination, combined.Bytes(), 0666)
+	err := os.WriteFile(destination, combined.Bytes(), 0666)
 	if err != nil {
 		return fmt.Errorf("Unable to create combined cover profile:\n%s", err.Error())
 	}

--- a/ginkgo/internal/test_suite.go
+++ b/ginkgo/internal/test_suite.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"errors"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -220,7 +219,7 @@ func suitesInDir(dir string, recurse bool) TestSuites {
 		return suites
 	}
 
-	files, _ := ioutil.ReadDir(dir)
+	files, _ := os.ReadDir(dir)
 	re := regexp.MustCompile(`^[^._].*_test\.go$`)
 	for _, file := range files {
 		if !file.IsDir() && re.Match([]byte(file.Name())) {
@@ -264,13 +263,13 @@ func packageNameForSuite(dir string) string {
 	return filepath.Base(path)
 }
 
-func filesHaveGinkgoSuite(dir string, files []os.FileInfo) bool {
+func filesHaveGinkgoSuite(dir string, files []os.DirEntry) bool {
 	reTestFile := regexp.MustCompile(`_test\.go$`)
 	reGinkgo := regexp.MustCompile(`package ginkgo|\/ginkgo"`)
 
 	for _, file := range files {
 		if !file.IsDir() && reTestFile.Match([]byte(file.Name())) {
-			contents, _ := ioutil.ReadFile(dir + "/" + file.Name())
+			contents, _ := os.ReadFile(dir + "/" + file.Name())
 			if reGinkgo.Match(contents) {
 				return true
 			}

--- a/ginkgo/internal/testsuite_test.go
+++ b/ginkgo/internal/testsuite_test.go
@@ -1,7 +1,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -44,14 +43,14 @@ var _ = Describe("TestSuite", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 
 			path = filepath.Join(path, filename)
-			ioutil.WriteFile(path, []byte(content), mode)
+			os.WriteFile(path, []byte(content), mode)
 		}
 
 		BeforeEach(func() {
 			cliConf = types.CLIConfig{}
 
 			var err error
-			tmpDir, err = ioutil.TempDir("/tmp", "ginkgo")
+			tmpDir, err = os.MkdirTemp("/tmp", "ginkgo")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			origWd, err = os.Getwd()

--- a/ginkgo/internal/utils_test.go
+++ b/ginkgo/internal/utils_test.go
@@ -1,7 +1,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,7 +17,7 @@ var _ = Describe("Utils", func() {
 
 		BeforeEach(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("/tmp", "ginkgo")
+			tmpDir, err = os.MkdirTemp("/tmp", "ginkgo")
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
@@ -28,7 +27,7 @@ var _ = Describe("Utils", func() {
 
 		It("returns true if the path exists", func() {
 			path := filepath.Join(tmpDir, "foo")
-			Ω(ioutil.WriteFile(path, []byte("foo"), 0666)).Should(Succeed())
+			Ω(os.WriteFile(path, []byte("foo"), 0666)).Should(Succeed())
 			Ω(internal.FileExists(path)).Should(BeTrue())
 		})
 

--- a/ginkgo/nodot/nodot_command.go
+++ b/ginkgo/nodot/nodot_command.go
@@ -2,7 +2,6 @@ package nodot
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -31,13 +30,13 @@ If you've renamed a declaration, that name will be honored and not overwritten.`
 func updateNodot() {
 	suiteFile, perm := findSuiteFile()
 
-	data, err := ioutil.ReadFile(suiteFile)
+	data, err := os.ReadFile(suiteFile)
 	command.AbortIfError("Failed to read boostrap file:", err)
 
 	content, err := ApplyNoDot(data)
 	command.AbortIfError("Failed to update nodot declarations:", err)
 
-	ioutil.WriteFile(suiteFile, content, perm)
+	os.WriteFile(suiteFile, content, perm)
 
 	internal.GoFmt(suiteFile)
 }
@@ -46,7 +45,7 @@ func findSuiteFile() (string, os.FileMode) {
 	workingDir, err := os.Getwd()
 	command.AbortIfError("Could not find suite file for nodot:", err)
 
-	files, err := ioutil.ReadDir(workingDir)
+	files, err := os.ReadDir(workingDir)
 	command.AbortIfError("Could not find suite file for nodot:", err)
 
 	re := regexp.MustCompile(`RunSpecs\(|RunSpecsWithDefaultAndCustomReporters\(|RunSpecsWithCustomReporters\(`)
@@ -61,7 +60,9 @@ func findSuiteFile() (string, os.FileMode) {
 		defer f.Close()
 
 		if re.MatchReader(bufio.NewReader(f)) {
-			return path, file.Mode()
+			fileInfo, err := file.Info()
+			command.AbortIfError("Could not find suite file for nodot:", err)
+			return path, fileInfo.Mode()
 		}
 	}
 

--- a/ginkgo/outline/outline_test.go
+++ b/ginkgo/outline/outline_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,14 +32,14 @@ var _ = DescribeTable("Validate outline from file with",
 		gotJSON, err := json.MarshalIndent(o, "", "  ")
 		Expect(err).To(BeNil(), "error marshalling outline to json: %s", err)
 
-		wantJSON, err := ioutil.ReadFile(filepath.Join("_testdata", jsonOutlineFilename))
+		wantJSON, err := os.ReadFile(filepath.Join("_testdata", jsonOutlineFilename))
 		Expect(err).To(BeNil(), "error reading JSON outline fixture: %s", err)
 
 		Expect(gotJSON).To(MatchJSON(wantJSON))
 
 		gotCSV := o.String()
 
-		wantCSV, err := ioutil.ReadFile(filepath.Join("_testdata", csvOutlineFilename))
+		wantCSV, err := os.ReadFile(filepath.Join("_testdata", csvOutlineFilename))
 		Expect(err).To(BeNil(), "error reading CSV outline fixture: %s", err)
 
 		Expect(gotCSV).To(Equal(string(wantCSV)))

--- a/ginkgo/performance/performance_suite_test.go
+++ b/ginkgo/performance/performance_suite_test.go
@@ -3,7 +3,6 @@ package performance_test
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -135,7 +134,7 @@ func (f PerformanceFixtureManager) MountFixture(fixture string, subPackage ...st
 func (f PerformanceFixtureManager) copyIn(src string, dst string) {
 	Expect(os.MkdirAll(dst, 0777)).To(Succeed())
 
-	files, err := ioutil.ReadDir(src)
+	files, err := os.ReadDir(src)
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, file := range files {
@@ -146,9 +145,9 @@ func (f PerformanceFixtureManager) copyIn(src string, dst string) {
 			continue
 		}
 
-		srcContent, err := ioutil.ReadFile(srcPath)
+		srcContent, err := os.ReadFile(srcPath)
 		Ω(err).ShouldNot(HaveOccurred())
-		Ω(ioutil.WriteFile(dstPath, srcContent, 0666)).Should(Succeed())
+		Ω(os.WriteFile(dstPath, srcContent, 0666)).Should(Succeed())
 	}
 }
 

--- a/ginkgo/unfocus/unfocus_command.go
+++ b/ginkgo/unfocus/unfocus_command.go
@@ -7,7 +7,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ func unfocusSpecs() {
 }
 
 func unfocusDir(goFiles chan string, path string) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		fmt.Println(err.Error())
 		return
@@ -79,7 +78,7 @@ func shouldProcessFile(basename string) bool {
 }
 
 func unfocusFile(path string) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Printf("error reading file '%s': %s\n", path, err.Error())
 		return
@@ -112,7 +111,7 @@ func unfocusFile(path string) {
 }
 
 func writeBackup(path string, data []byte) (string, error) {
-	t, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
+	t, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
 
 	if err != nil {
 		return "", fmt.Errorf("error creating temporary file: %w", err)

--- a/ginkgo/watch/package_hash.go
+++ b/ginkgo/watch/package_hash.go
@@ -2,7 +2,6 @@ package watch
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"time"
@@ -63,15 +62,20 @@ func (p *PackageHash) CheckForChanges() bool {
 }
 
 func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Time, testHash string, testModifiedTime time.Time, deleted bool) {
-	infos, err := ioutil.ReadDir(p.path)
+	entries, err := os.ReadDir(p.path)
 
 	if err != nil {
 		deleted = true
 		return
 	}
 
-	for _, info := range infos {
-		if info.IsDir() {
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onsi/ginkgo
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0

--- a/integration/_fixtures/eventually_failing_fixture/eventually_failing_test.go
+++ b/integration/_fixtures/eventually_failing_fixture/eventually_failing_test.go
@@ -2,7 +2,7 @@ package eventually_failing_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -13,7 +13,7 @@ import (
 var _ = Describe("EventuallyFailing", func() {
 	It("should fail on the third try", func() {
 		time.Sleep(time.Second)
-		files, err := ioutil.ReadDir(".")
+		files, err := os.ReadDir(".")
 		Ω(err).ShouldNot(HaveOccurred())
 
 		numRuns := 1
@@ -24,6 +24,6 @@ var _ = Describe("EventuallyFailing", func() {
 		}
 
 		Ω(numRuns).Should(BeNumerically("<", 3))
-		ioutil.WriteFile(fmt.Sprintf("./counter-%d", numRuns), []byte("foo"), 0777)
+		os.WriteFile(fmt.Sprintf("./counter-%d", numRuns), []byte("foo"), 0777)
 	})
 })

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -91,7 +90,7 @@ func (f FixtureManager) MountFixture(fixture string, subPackage ...string) {
 func (f FixtureManager) copyAndRewrite(src string, dst string) {
 	Expect(os.MkdirAll(dst, 0777)).To(Succeed())
 
-	files, err := ioutil.ReadDir(src)
+	files, err := os.ReadDir(src)
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, file := range files {
@@ -102,12 +101,12 @@ func (f FixtureManager) copyAndRewrite(src string, dst string) {
 			continue
 		}
 
-		srcContent, err := ioutil.ReadFile(srcPath)
+		srcContent, err := os.ReadFile(srcPath)
 		Ω(err).ShouldNot(HaveOccurred())
 		//rewrite import statements so that fixtures can work in the fixture folder when developing them, and in the tmp folder when under test
 		srcContent = bytes.ReplaceAll(srcContent, []byte("github.com/onsi/ginkgo/integration/_fixtures"), []byte(f.PackageRoot()))
 		srcContent = bytes.ReplaceAll(srcContent, []byte("_fixture"), []byte(""))
-		Ω(ioutil.WriteFile(dstPath, srcContent, 0666)).Should(Succeed())
+		Ω(os.WriteFile(dstPath, srcContent, 0666)).Should(Succeed())
 	}
 }
 
@@ -130,12 +129,12 @@ func (f FixtureManager) PathToFixtureFile(pkg string, target string) string {
 
 func (f FixtureManager) WriteFile(pkg string, target string, content string) {
 	dst := f.PathTo(pkg, target)
-	err := ioutil.WriteFile(dst, []byte(content), 0666)
+	err := os.WriteFile(dst, []byte(content), 0666)
 	Ω(err).ShouldNot(HaveOccurred())
 }
 
 func (f FixtureManager) ContentOf(pkg string, target string) string {
-	content, err := ioutil.ReadFile(f.PathTo(pkg, target))
+	content, err := os.ReadFile(f.PathTo(pkg, target))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return string(content)
 }
@@ -155,7 +154,7 @@ func (f FixtureManager) LoadJUnitReport(pkg string, target string) reporters.JUn
 }
 
 func (f FixtureManager) ContentOfFixture(pkg string, target string) string {
-	content, err := ioutil.ReadFile(f.PathToFixtureFile(pkg, target))
+	content, err := os.ReadFile(f.PathToFixtureFile(pkg, target))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return string(content)
 }
@@ -173,16 +172,16 @@ func (f FixtureManager) PackageNameFor(target string) string {
 }
 
 func sameFile(filePath, otherFilePath string) bool {
-	content, readErr := ioutil.ReadFile(filePath)
+	content, readErr := os.ReadFile(filePath)
 	Expect(readErr).NotTo(HaveOccurred())
-	otherContent, readErr := ioutil.ReadFile(otherFilePath)
+	otherContent, readErr := os.ReadFile(otherFilePath)
 	Expect(readErr).NotTo(HaveOccurred())
 	Expect(string(content)).To(Equal(string(otherContent)))
 	return true
 }
 
 func sameFolder(sourcePath, destinationPath string) bool {
-	files, err := ioutil.ReadDir(sourcePath)
+	files, err := os.ReadDir(sourcePath)
 	Expect(err).NotTo(HaveOccurred())
 	for _, f := range files {
 		srcPath := filepath.Join(sourcePath, f.Name())

--- a/integration/reporting_test.go
+++ b/integration/reporting_test.go
@@ -1,7 +1,7 @@
 package integration_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -23,7 +23,7 @@ var _ = Describe("Reporting", func() {
 			session := startGinkgo(fm.PathTo("reporting"), "--no-color")
 			Eventually(session).Should(gexec.Exit(1))
 
-			report, err := ioutil.ReadFile(fm.PathTo("reporting", "report-after-each.out"))
+			report, err := os.ReadFile(fm.PathTo("reporting", "report-after-each.out"))
 			Ω(err).ShouldNot(HaveOccurred())
 			lines := strings.Split(string(report), "\n")
 			Ω(lines).Should(ConsistOf(
@@ -40,7 +40,7 @@ var _ = Describe("Reporting", func() {
 			session := startGinkgo(fm.PathTo("reporting"), "--no-color", "--seed=17")
 			Eventually(session).Should(gexec.Exit(1))
 
-			report, err := ioutil.ReadFile(fm.PathTo("reporting", "report-after-suite.out"))
+			report, err := os.ReadFile(fm.PathTo("reporting", "report-after-suite.out"))
 			Ω(err).ShouldNot(HaveOccurred())
 			lines := strings.Split(string(report), "\n")
 			Ω(lines).Should(ConsistOf(
@@ -61,7 +61,7 @@ var _ = Describe("Reporting", func() {
 				session := startGinkgo(fm.PathTo("reporting"), "--no-color", "--seed=17", "--nodes=2")
 				Eventually(session).Should(gexec.Exit(1))
 
-				report, err := ioutil.ReadFile(fm.PathTo("reporting", "report-after-suite.out"))
+				report, err := os.ReadFile(fm.PathTo("reporting", "report-after-suite.out"))
 				Ω(err).ShouldNot(HaveOccurred())
 				lines := strings.Split(string(report), "\n")
 				Ω(lines).Should(ConsistOf(

--- a/integration/subcommand_test.go
+++ b/integration/subcommand_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ var _ = Describe("Subcommand", func() {
 
 			Ω(output).Should(ContainSubstring("foo_suite_test.go"))
 
-			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			content, err := os.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("package foo_test"))
 			Ω(content).Should(ContainSubstring("func TestFoo(t *testing.T) {"))
@@ -51,7 +50,7 @@ var _ = Describe("Subcommand", func() {
 
 			Ω(output).Should(ContainSubstring("foo_suite_test.go"))
 
-			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			content, err := os.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("package foo_test"))
 			Ω(content).Should(ContainSubstring("func TestFoo(t *testing.T) {"))
@@ -67,7 +66,7 @@ var _ = Describe("Subcommand", func() {
 
 		It("should generate a bootstrap file using a template when told to", func() {
 			templateFile := filepath.Join(pkgPath, ".bootstrap")
-			ioutil.WriteFile(templateFile, []byte(`package {{.Package}}
+			os.WriteFile(templateFile, []byte(`package {{.Package}}
 
 			import (
 				{{.GinkgoImport}}
@@ -86,7 +85,7 @@ var _ = Describe("Subcommand", func() {
 
 			Ω(output).Should(ContainSubstring("foo_suite_test.go"))
 
-			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			content, err := os.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("package foo_test"))
 			Ω(content).Should(ContainSubstring(`. "github.com/onsi/ginkgo"`))
@@ -97,7 +96,7 @@ var _ = Describe("Subcommand", func() {
 
 		It("should generate a bootstrap file using a template that contains functions when told to", func() {
 			templateFile := filepath.Join(pkgPath, ".bootstrap")
-			ioutil.WriteFile(templateFile, []byte(`package {{.Package}}
+			os.WriteFile(templateFile, []byte(`package {{.Package}}
 
 			import (
 				{{.GinkgoImport}}
@@ -116,7 +115,7 @@ var _ = Describe("Subcommand", func() {
 
 			Ω(output).Should(ContainSubstring("foo_suite_test.go"))
 
-			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			content, err := os.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("package foo_test"))
 			Ω(content).Should(ContainSubstring(`. "github.com/onsi/ginkgo"`))
@@ -134,20 +133,20 @@ var _ = Describe("Subcommand", func() {
 			session := startGinkgo(pkgPath, "bootstrap", "--nodot")
 			Eventually(session).Should(gexec.Exit(0))
 
-			byteContent, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			byteContent, err := os.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			content := string(byteContent)
 			content = strings.Replace(content, "var It =", "var MyIt =", -1)
 			content = strings.Replace(content, "var Ω = gomega.Ω\n", "", -1)
 
-			err = ioutil.WriteFile(filepath.Join(pkgPath, "foo_suite_test.go"), []byte(content), os.ModePerm)
+			err = os.WriteFile(filepath.Join(pkgPath, "foo_suite_test.go"), []byte(content), os.ModePerm)
 			Ω(err).ShouldNot(HaveOccurred())
 
 			session = startGinkgo(pkgPath, "nodot")
 			Eventually(session).Should(gexec.Exit(0))
 
-			byteContent, err = ioutil.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
+			byteContent, err = os.ReadFile(filepath.Join(pkgPath, "foo_suite_test.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(byteContent).Should(ContainSubstring("var MyIt = ginkgo.It"))
@@ -172,7 +171,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("foo_bar_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("FooBar", func() {`))
@@ -191,7 +190,7 @@ var _ = Describe("Subcommand", func() {
 		Context("with template argument", func() {
 			It("should generate a test file using a template", func() {
 				templateFile := filepath.Join(pkgPath, ".generate")
-				ioutil.WriteFile(templateFile, []byte(`package {{.Package}}
+				os.WriteFile(templateFile, []byte(`package {{.Package}}
 				import (
 					{{if .IncludeImports}}. "github.com/onsi/ginkgo"{{end}}
 					{{if .IncludeImports}}. "github.com/onsi/gomega"{{end}}
@@ -208,7 +207,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("foo_bar_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`. "github.com/onsi/ginkgo"`))
@@ -219,7 +218,7 @@ var _ = Describe("Subcommand", func() {
 
 			It("should generate a test file using a template that contains functions", func() {
 				templateFile := filepath.Join(pkgPath, ".generate")
-				ioutil.WriteFile(templateFile, []byte(`package {{.Package}}
+				os.WriteFile(templateFile, []byte(`package {{.Package}}
 				import (
 					{{if .IncludeImports}}. "github.com/onsi/ginkgo"{{end}}
 					{{if .IncludeImports}}. "github.com/onsi/gomega"{{end}}
@@ -236,7 +235,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("foo_bar_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`. "github.com/onsi/ginkgo"`))
@@ -254,7 +253,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("baz_buzz_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("BazBuzz", func() {`))
@@ -269,7 +268,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("baz_buzz_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("BazBuzz", func() {`))
@@ -285,7 +284,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("baz_buzz_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("BazBuzz", func() {`))
@@ -300,7 +299,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("baz_buzz_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("BazBuzz", func() {`))
@@ -315,7 +314,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("baz_buzz_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "baz_buzz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("BazBuzz", func() {`))
@@ -331,12 +330,12 @@ var _ = Describe("Subcommand", func() {
 				Ω(output).Should(ContainSubstring("baz_test.go"))
 				Ω(output).Should(ContainSubstring("buzz_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "baz_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "baz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("Baz", func() {`))
 
-				content, err = ioutil.ReadFile(filepath.Join(pkgPath, "buzz_test.go"))
+				content, err = os.ReadFile(filepath.Join(pkgPath, "buzz_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring(`var _ = Describe("Buzz", func() {`))
@@ -351,7 +350,7 @@ var _ = Describe("Subcommand", func() {
 
 				Ω(output).Should(ContainSubstring("foo_bar_test.go"))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "foo_bar_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).ShouldNot(ContainSubstring("\t" + `. "github.com/onsi/ginkgo"`))
@@ -372,7 +371,7 @@ var _ = Describe("Subcommand", func() {
 				session := startGinkgo(pkgPath, "bootstrap")
 				Eventually(session).Should(gexec.Exit(0))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_suite_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_suite_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package some_crazy_thing_test"))
 				Ω(content).Should(ContainSubstring("SomeCrazyThing Suite"))
@@ -380,7 +379,7 @@ var _ = Describe("Subcommand", func() {
 				session = startGinkgo(pkgPath, "generate")
 				Eventually(session).Should(gexec.Exit(0))
 
-				content, err = ioutil.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_test.go"))
+				content, err = os.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package some_crazy_thing_test"))
 				Ω(content).Should(ContainSubstring("SomeCrazyThing"))
@@ -389,14 +388,14 @@ var _ = Describe("Subcommand", func() {
 
 		Context("when the working directory contains a file with a package name", func() {
 			BeforeEach(func() {
-				Ω(ioutil.WriteFile(filepath.Join(pkgPath, "foo.go"), []byte("package main\n\nfunc main() {}"), 0777)).Should(Succeed())
+				Ω(os.WriteFile(filepath.Join(pkgPath, "foo.go"), []byte("package main\n\nfunc main() {}"), 0777)).Should(Succeed())
 			})
 
 			It("generates correctly named bootstrap and generate files with the package name", func() {
 				session := startGinkgo(pkgPath, "bootstrap")
 				Eventually(session).Should(gexec.Exit(0))
 
-				content, err := ioutil.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_suite_test.go"))
+				content, err := os.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_suite_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package main_test"))
 				Ω(content).Should(ContainSubstring("SomeCrazyThing Suite"))
@@ -404,7 +403,7 @@ var _ = Describe("Subcommand", func() {
 				session = startGinkgo(pkgPath, "generate")
 				Eventually(session).Should(gexec.Exit(0))
 
-				content, err = ioutil.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_test.go"))
+				content, err = os.ReadFile(filepath.Join(pkgPath, "some_crazy_thing_test.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("package main_test"))
 				Ω(content).Should(ContainSubstring("SomeCrazyThing"))
@@ -421,7 +420,7 @@ var _ = Describe("Subcommand", func() {
 		BeforeEach(func() {
 			pkgPath = fm.TmpDir + "/myamazingmodule"
 			Ω(os.Mkdir(pkgPath, 0777)).Should(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(pkgPath, "go.mod"), []byte("module fake.com/me/myamazingmodule\n"), 0777)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(pkgPath, "go.mod"), []byte("module fake.com/me/myamazingmodule\n"), 0777)).To(Succeed())
 			savedGoPath = os.Getenv("GOPATH")
 			Expect(os.Setenv("GOPATH", "")).To(Succeed())
 			Expect(os.Setenv("GO111MODULE", "on")).To(Succeed()) // needed pre-Go 1.13
@@ -436,7 +435,7 @@ var _ = Describe("Subcommand", func() {
 			session := startGinkgo(pkgPath, "bootstrap")
 			Eventually(session).Should(gexec.Exit(0))
 
-			content, err := ioutil.ReadFile(filepath.Join(pkgPath, "myamazingmodule_suite_test.go"))
+			content, err := os.ReadFile(filepath.Join(pkgPath, "myamazingmodule_suite_test.go"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("package myamazingmodule_test"), string(content))
 			Expect(content).To(ContainSubstring("Myamazingmodule Suite"), string(content))
@@ -444,7 +443,7 @@ var _ = Describe("Subcommand", func() {
 			session = startGinkgo(pkgPath, "generate")
 			Eventually(session).Should(gexec.Exit(0))
 
-			content, err = ioutil.ReadFile(filepath.Join(pkgPath, "myamazingmodule_test.go"))
+			content, err = os.ReadFile(filepath.Join(pkgPath, "myamazingmodule_test.go"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("package myamazingmodule_test"), string(content))
 			Expect(content).To(ContainSubstring("fake.com/me/myamazingmodule"), string(content))

--- a/integration/watch_test.go
+++ b/integration/watch_test.go
@@ -1,7 +1,7 @@
 package integration_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -22,10 +22,10 @@ var _ = Describe("Watch", func() {
 
 	modifyFile := func(path string) {
 		time.Sleep(time.Second)
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		Ω(err).ShouldNot(HaveOccurred())
 		content = append(content, []byte("//")...)
-		err = ioutil.WriteFile(path, content, 0666)
+		err = os.WriteFile(path, content, 0666)
 		Ω(err).ShouldNot(HaveOccurred())
 	}
 

--- a/internal/internal_integration/internal_integration_suite_test.go
+++ b/internal/internal_integration/internal_integration_suite_test.go
@@ -1,17 +1,16 @@
 package internal_integration_test
 
 import (
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/internal"
+	"github.com/onsi/ginkgo/internal/global"
 	. "github.com/onsi/ginkgo/internal/test_helpers"
 	"github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/internal"
-	"github.com/onsi/ginkgo/internal/global"
 )
 
 func TestSuiteTests(t *testing.T) {
@@ -31,7 +30,7 @@ var outputInterceptor *FakeOutputInterceptor
 var _ = BeforeEach(func() {
 	conf = types.SuiteConfig{}
 	failer = internal.NewFailer()
-	writer = internal.NewWriter(ioutil.Discard)
+	writer = internal.NewWriter(io.Discard)
 	writer.SetMode(internal.WriterModeBufferOnly)
 	reporter = &FakeReporter{}
 	rt = NewRunTracker()

--- a/internal/parallel_support/parallel_support_suite_test.go
+++ b/internal/parallel_support/parallel_support_suite_test.go
@@ -2,7 +2,6 @@ package parallel_support_test
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	. "github.com/onsi/ginkgo"
@@ -33,7 +32,7 @@ func newFakePoster() *fakePoster {
 }
 
 func (poster *fakePoster) Post(url string, bodyType string, body io.Reader) (resp *http.Response, err error) {
-	bodyContent, _ := ioutil.ReadAll(body)
+	bodyContent, _ := io.ReadAll(body)
 	poster.posts = append(poster.posts, post{
 		url:         url,
 		bodyType:    bodyType,

--- a/internal/parallel_support/server.go
+++ b/internal/parallel_support/server.go
@@ -9,7 +9,7 @@ package parallel_support
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -220,7 +220,7 @@ func (server *Server) handleBeforeSuiteSucceeded(writer http.ResponseWriter, req
 	defer server.lock.Unlock()
 	server.beforeSuiteState.State = types.SpecStatePassed
 	var err error
-	server.beforeSuiteState.Data, err = ioutil.ReadAll(request.Body)
+	server.beforeSuiteState.Data, err = io.ReadAll(request.Body)
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
 	}

--- a/internal/suite_test.go
+++ b/internal/suite_test.go
@@ -2,16 +2,14 @@ package internal_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	"github.com/onsi/ginkgo/internal"
 	"github.com/onsi/ginkgo/internal/interrupt_handler"
 	. "github.com/onsi/ginkgo/internal/test_helpers"
 	"github.com/onsi/ginkgo/types"
-
-	"github.com/onsi/ginkgo/internal"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Suite", func() {
@@ -30,7 +28,7 @@ var _ = Describe("Suite", func() {
 	BeforeEach(func() {
 		failer = internal.NewFailer()
 		reporter = &FakeReporter{}
-		writer = internal.NewWriter(ioutil.Discard)
+		writer = internal.NewWriter(io.Discard)
 		outputInterceptor = NewFakeOutputInterceptor()
 		interruptHandler = interrupt_handler.NewInterruptHandler(0, "")
 		conf = types.SuiteConfig{

--- a/internal/test_helpers/markdown_heading_loader.go
+++ b/internal/test_helpers/markdown_heading_loader.go
@@ -1,7 +1,7 @@
 package test_helpers
 
 import (
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -9,12 +9,12 @@ import (
 var punctuationRE = regexp.MustCompile(`[^\w\-\s]`)
 
 func LoadMarkdownHeadingAnchors(filename string) []string {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return []string{}
 	}
 
-	anchors := []string{}
+	var anchors []string
 	lines := strings.Split(string(b), "\n")
 	for _, line := range lines {
 		line = strings.TrimLeft(line, " ")

--- a/reporters/json_report.go
+++ b/reporters/json_report.go
@@ -3,7 +3,6 @@ package reporters
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/onsi/ginkgo/types"
@@ -33,7 +32,7 @@ func MergeAndCleanupJSONReports(sources []string, destination string) ([]string,
 	allReports := []types.Report{}
 	for _, source := range sources {
 		reports := []types.Report{}
-		data, err := ioutil.ReadFile(source)
+		data, err := os.ReadFile(source)
 		if err != nil {
 			messages = append(messages, fmt.Sprintf("Could not open %s:\n%s", source, err.Error()))
 			continue

--- a/reporters/teamcity_report.go
+++ b/reporters/teamcity_report.go
@@ -10,7 +10,6 @@ package reporters
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -76,7 +75,7 @@ func MergeAndCleanupTeamcityReports(sources []string, dst string) ([]string, err
 	messages := []string{}
 	merged := []byte{}
 	for _, source := range sources {
-		data, err := ioutil.ReadFile(source)
+		data, err := os.ReadFile(source)
 		if err != nil {
 			messages = append(messages, fmt.Sprintf("Could not open %s:\n%s", source, err.Error()))
 			continue
@@ -84,5 +83,5 @@ func MergeAndCleanupTeamcityReports(sources []string, dst string) ([]string, err
 		os.Remove(source)
 		merged = append(merged, data...)
 	}
-	return messages, ioutil.WriteFile(dst, merged, 0666)
+	return messages, os.WriteFile(dst, merged, 0666)
 }

--- a/types/flags.go
+++ b/types/flags.go
@@ -3,7 +3,7 @@ package types
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"time"
@@ -109,7 +109,7 @@ func bindFlagSet(f GinkgoFlagSet, flagSet *flag.FlagSet) (GinkgoFlagSet, error) 
 	if flagSet == nil {
 		f.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 		//supress all output as Ginkgo is reponsible for formatting usage
-		f.flagSet.SetOutput(ioutil.Discard)
+		f.flagSet.SetOutput(io.Discard)
 	} else {
 		f.flagSet = flagSet
 		//we're piggybacking on an existing flagset (typically go test) so we have limited control


### PR DESCRIPTION
This PR contains two Go 1.17 chores, and it's probably best to "rebase and merge" so that the individual commits are retained. The first commit has also been done on `master`, but the second one is only for `v2` since it's forward looking.