### PR TITLE
fix: remove duplicate imports

### DIFF
--- a/formatter/colorable_windows.go
+++ b/formatter/colorable_windows.go
@@ -39,9 +39,6 @@ import (
 	"strings"
 	"syscall"
 	"unsafe"
-
-	"syscall"
-	"unsafe"
 )
 
 var (


### PR DESCRIPTION
This fixes the windows build for V2.

```
$ go get github.com/onsi/ginkgo@ver2
# github.com/onsi/ginkgo/formatter
C:\dev\pkg\mod\github.com\onsi\ginkgo@v1.16.5-0.20210909195940-25ee1ae60f5e\formatter\colorable_windows.go:43:2: syscall redeclared as imported package name
        previous declaration at C:\dev\pkg\mod\github.com\onsi\ginkgo@v1.16.5-0.20210909195940-25ee1ae60f5e\formatter\colorable_windows.go:40:2
C:\dev\pkg\mod\github.com\onsi\ginkgo@v1.16.5-0.20210909195940-25ee1ae60f5e\formatter\colorable_windows.go:44:2: unsafe redeclared as imported package name
        previous declaration at C:\dev\pkg\mod\github.com\onsi\ginkgo@v1.16.5-0.20210909195940-25ee1ae60f5e\formatter\colorable_windows.go:41:2
```