### PR TITLE
Fix failure summary when there are multiple suites

### DIFF
--- a/ginkgo/run/run_command.go
+++ b/ginkgo/run/run_command.go
@@ -189,7 +189,7 @@ OUTER_LOOP:
 		}
 	} else {
 		fmt.Fprintln(formatter.ColorableStdOut, "")
-		if suites.CountWithState(internal.TestSuiteStateFailureStates...) > 1 {
+		if len(suites) > 1 && suites.CountWithState(internal.TestSuiteStateFailureStates...) > 0 {
 			fmt.Fprintln(formatter.ColorableStdOut,
 				internal.FailedSuitesReport(suites, formatter.NewWithNoColorBool(r.reporterConfig.NoColor)))
 		}


### PR DESCRIPTION
Print summary of failed suites when there is more than one suite and any of those fails.

Fixes #854 