### PR TITLE
Add //go:build lines

### DIFF
--- a/ginkgo/interrupthandler/sigquit_swallower_unix.go
+++ b/ginkgo/interrupthandler/sigquit_swallower_unix.go
@@ -1,3 +1,4 @@
+//go:build freebsd || openbsd || netbsd || dragonfly || darwin || linux || solaris
 // +build freebsd openbsd netbsd dragonfly darwin linux solaris
 
 package interrupthandler

--- a/ginkgo/interrupthandler/sigquit_swallower_windows.go
+++ b/ginkgo/interrupthandler/sigquit_swallower_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package interrupthandler

--- a/ginkgo/testrunner/build_args.go
+++ b/ginkgo/testrunner/build_args.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package testrunner

--- a/ginkgo/testrunner/build_args_old.go
+++ b/ginkgo/testrunner/build_args_old.go
@@ -1,3 +1,4 @@
+//go:build !go1.10
 // +build !go1.10
 
 package testrunner

--- a/ginkgo/testsuite/testsuite_test.go
+++ b/ginkgo/testsuite/testsuite_test.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package testsuite_test

--- a/ginkgo/testsuite/vendor_check_go15.go
+++ b/ginkgo/testsuite/vendor_check_go15.go
@@ -1,3 +1,4 @@
+//go:build !go1.6
 // +build !go1.6
 
 package testsuite

--- a/ginkgo/testsuite/vendor_check_go15_test.go
+++ b/ginkgo/testsuite/vendor_check_go15_test.go
@@ -1,3 +1,4 @@
+//go:build !go1.6
 // +build !go1.6
 
 package testsuite_test

--- a/ginkgo/testsuite/vendor_check_go16.go
+++ b/ginkgo/testsuite/vendor_check_go16.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package testsuite

--- a/internal/remote/output_interceptor_unix.go
+++ b/internal/remote/output_interceptor_unix.go
@@ -1,3 +1,4 @@
+//go:build freebsd || openbsd || netbsd || dragonfly || darwin || linux || solaris
 // +build freebsd openbsd netbsd dragonfly darwin linux solaris
 
 package remote

--- a/internal/remote/output_interceptor_win.go
+++ b/internal/remote/output_interceptor_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package remote

--- a/reporters/junit_reporter.go
+++ b/reporters/junit_reporter.go
@@ -160,7 +160,7 @@ func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	if err == nil {
 		fmt.Fprintf(os.Stdout, "\nJUnit report was created: %s\n", filePath)
 	} else {
-		fmt.Fprintf(os.Stderr,"\nFailed to generate JUnit report data:\n\t%s", err.Error())
+		fmt.Fprintf(os.Stderr, "\nFailed to generate JUnit report data:\n\t%s", err.Error())
 	}
 }
 

--- a/reporters/stenographer/support/go-colorable/colorable_others.go
+++ b/reporters/stenographer/support/go-colorable/colorable_others.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package colorable

--- a/reporters/stenographer/support/go-isatty/isatty_appengine.go
+++ b/reporters/stenographer/support/go-isatty/isatty_appengine.go
@@ -1,3 +1,4 @@
+//go:build appengine
 // +build appengine
 
 package isatty

--- a/reporters/stenographer/support/go-isatty/isatty_bsd.go
+++ b/reporters/stenographer/support/go-isatty/isatty_bsd.go
@@ -1,3 +1,4 @@
+//go:build (darwin || freebsd || openbsd || netbsd) && !appengine
 // +build darwin freebsd openbsd netbsd
 // +build !appengine
 

--- a/reporters/stenographer/support/go-isatty/isatty_linux.go
+++ b/reporters/stenographer/support/go-isatty/isatty_linux.go
@@ -1,5 +1,5 @@
-// +build linux
-// +build !appengine
+//go:build linux && !appengine
+// +build linux,!appengine
 
 package isatty
 

--- a/reporters/stenographer/support/go-isatty/isatty_solaris.go
+++ b/reporters/stenographer/support/go-isatty/isatty_solaris.go
@@ -1,5 +1,5 @@
-// +build solaris
-// +build !appengine
+//go:build solaris && !appengine
+// +build solaris,!appengine
 
 package isatty
 

--- a/reporters/stenographer/support/go-isatty/isatty_windows.go
+++ b/reporters/stenographer/support/go-isatty/isatty_windows.go
@@ -1,5 +1,5 @@
-// +build windows
-// +build !appengine
+//go:build windows && !appengine
+// +build windows,!appengine
 
 package isatty
 


### PR DESCRIPTION
Starting with Go 1.17, `//go:build` lines are preferred over `// +build`
lines, see https://golang.org/doc/go1.17#build-lines and
https://golang.org/design/draft-gobuild for details.

This change was generated by running Go 1.17 `go fmt ./...` which
automatically adds `//go:build` lines based on the existing `// +build`
lines.