### PR TITLE
Add error check for invalid/nil parameters to DescribeTable

### DIFF
--- a/table_dsl.go
+++ b/table_dsl.go
@@ -135,8 +135,10 @@ func generateTable(description string, args ...interface{}) {
 		return "Entry: " + strings.Join(out, ", ")
 	}
 
-	for _, arg := range args {
+	for i, arg := range args {
 		switch t := reflect.TypeOf(arg); {
+		case t == nil:
+			exitIfErr(types.GinkgoErrors.IncorrectParameterTypeForTable(i, "nil", cl))
 		case t == reflect.TypeOf(TableEntry{}):
 			entries = append(entries, arg.(TableEntry))
 		case t == reflect.TypeOf([]TableEntry{}):

--- a/types/errors.go
+++ b/types/errors.go
@@ -370,6 +370,15 @@ func (g ginkgoErrors) InvalidEntryDescription(cl CodeLocation) error {
 	}
 }
 
+func (g ginkgoErrors) IncorrectParameterTypeForTable(i int, name string, cl CodeLocation) error {
+	return GinkgoError{
+		Heading:      "DescribeTable passed incorrect parameter type",
+		Message:      fmt.Sprintf("Parameter #%d passed to DescribeTable is of incorrect type <%s>", i, name),
+		CodeLocation: cl,
+		DocLink:      "table-specs",
+	}
+}
+
 func (g ginkgoErrors) TooFewParametersToTableFunction(expected, actual int, kind string, cl CodeLocation) error {
 	return GinkgoError{
 		Heading:      fmt.Sprintf("Too few parameters passed in to %s", kind),


### PR DESCRIPTION
This PR adds a check for nil Entry parameters to DescribeTable. If a nil entry is (accidentally) given, the reported error message is misleading:
```
Ginkgo detected a panic while constructing the spec tree.
You may be trying to make an assertion in the body of a container node
```

This came up when I wrote a test that looked like this, which caused the above issue and took me a while to find:
```go
var _ = Describe("Test", func() {
  DescribeTable("Test",
    func(..., matchErr interface{}) {
      err := ... // test logic
      if matchErr != nil {
        Expect(err).To(MatchError(matchErr))
      }
    },
    Entry(nil, "test", uuid.New(), []byte("test"), nil),
    Entry(nil, "", uuid.New(), []byte("")), nil,  // <- subtle syntax error!
    Entry(nil, "", uuid.Nil, []byte(""), "error message"),
  )
})
```

The implementation of generateTable panics since it expects reflect.TypeOf(entry) != nil for all entries, and the resulting panic stack trace is hidden from the output.
