### PR TITLE
Fix an example in the Spec Parallelization section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1731,7 +1731,7 @@ Describe("Storing books in an external database", func() {
   Context("when a book is in the database", func() {
     var book *books.Book
     BeforeEach(func() {
-      lesMiserables = &books.Book{
+      book = &books.Book{
         Title:  "Les Miserables",
         Author: "Victor Hugo",
         Pages:  2783,


### PR DESCRIPTION
In the example code in the subsection, Discovering Which Parallel Process a Spec is Running On, the closure variable should be `book`.