### PR TITLE
Correct typos in errors

### DIFF
--- a/core_dsl.go
+++ b/core_dsl.go
@@ -221,7 +221,7 @@ func RunSpecs(t GinkgoTestingT, description string, args ...interface{}) bool {
 		case Labels:
 			suiteLabels = append(suiteLabels, arg...)
 		default:
-			configErrors = append(configErrors, types.GinkgoErrors.UnkownTypePassedToRunSpecs(arg))
+			configErrors = append(configErrors, types.GinkgoErrors.UnknownTypePassedToRunSpecs(arg))
 		}
 	}
 	exitIfErrors(configErrors)

--- a/ginkgo/command/program_test.go
+++ b/ginkgo/command/program_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Program", func() {
 		})
 	})
 
-	Context("when called with an unkown subcommand", func() {
+	Context("when called with an unknown subcommand", func() {
 		BeforeEach(func() {
 			program.RunAndExit([]string{"omicron", "xi"})
 		})
@@ -283,7 +283,7 @@ var _ = Describe("Program", func() {
 		})
 	})
 
-	Context("when an unkown flag is used", func() {
+	Context("when an unknown flag is used", func() {
 		BeforeEach(func() {
 			program.RunAndExit([]string{"omicron", "beta", "-zanzibar"})
 		})

--- a/integration/suite_setup_test.go
+++ b/integration/suite_setup_test.go
@@ -78,7 +78,7 @@ var _ = Describe("SuiteSetup", func() {
 			Eventually(session).Should(gexec.Exit(1))
 			output := string(session.Out.Contents()) + string(session.Err.Contents())
 
-			Ω(output).Should(ContainSubstring("Process #1 disappeard before SynchronizedBeforeSuite could report back"))
+			Ω(output).Should(ContainSubstring("Process #1 disappeared before SynchronizedBeforeSuite could report back"))
 			Ω(output).Should(ContainSubstring("Ginkgo timed out waiting for all parallel procs to report back"))
 		})
 	})

--- a/types/errors.go
+++ b/types/errors.go
@@ -182,8 +182,8 @@ func (g ginkgoErrors) InvalidDeclarationOfFocusedAndPending(cl CodeLocation, nod
 
 func (g ginkgoErrors) UnknownDecorator(cl CodeLocation, nodeType NodeType, decorator interface{}) error {
 	return GinkgoError{
-		Heading:      "Unkown Decorator",
-		Message:      formatter.F(`[%s] node was passed an unkown decorator: '%#v'`, nodeType, decorator),
+		Heading:      "Unknown Decorator",
+		Message:      formatter.F(`[%s] node was passed an unknown decorator: '%#v'`, nodeType, decorator),
 		CodeLocation: cl,
 		DocLink:      "node-decorators-overview",
 	}
@@ -433,16 +433,16 @@ func (g ginkgoErrors) SynchronizedBeforeSuiteFailedOnProc1() error {
 
 func (g ginkgoErrors) SynchronizedBeforeSuiteDisappearedOnProc1() error {
 	return GinkgoError{
-		Heading: "Process #1 disappeard before SynchronizedBeforeSuite could report back",
+		Heading: "Process #1 disappeared before SynchronizedBeforeSuite could report back",
 		Message: "Ginkgo parallel process #1 disappeared before the first SynchronizedBeforeSuite function completed.  This suite will now abort.",
 	}
 }
 
 /* Configuration errors */
 
-func (g ginkgoErrors) UnkownTypePassedToRunSpecs(value interface{}) error {
+func (g ginkgoErrors) UnknownTypePassedToRunSpecs(value interface{}) error {
 	return GinkgoError{
-		Heading: "Unkown Type pased to RunSpecs",
+		Heading: "Unknown Type passed to RunSpecs",
 		Message: fmt.Sprintf("RunSpecs() accepts labels, and configuration of type types.SuiteConfig and/or types.ReporterConfig.\n You passed in: %v", value),
 	}
 }


### PR DESCRIPTION
There were a few typos I noticed in the `errors.go` file. There should be no functional impact on the codebase, although one function signature has been changed.