### PR TITLE
typo in example code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -398,7 +398,7 @@ var _ = Describe("Books", func() {
       })  
 
       It("can extract the author's last name", func() {        
-        Expect(book.AuthorLastName()).To(Equal("Victor"))
+        Expect(book.AuthorLastName()).To(Equal("Hugo"))
       })
 
       It("can extract the author's first name", func() {


### PR DESCRIPTION
In this example, the last name should be Hugo, not Victor. 