### PR TITLE
chore: test against Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.16', '1.17' ]
+        version: [ '1.16', '1.17', '1.18' ]
     name: Go ${{ matrix.version }}
     steps:
     - uses: actions/setup-go@v2


### PR DESCRIPTION
This adds testing for the new Go 1.18. Although Go 1.16 is now unsupported, we know from experience that many folks will still be using it, so we should still try to maintain compatibility where it's easy.