### PR TITLE
Update docs to reflect Go v1.18 installation changes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,11 +35,11 @@ In this section we cover installing Ginkgo, Gomega, and the `ginkgo` CLI.  We bo
 
 ### Installing Ginkgo
 
-Ginkgo uses [go modules](https://go.dev/blog/using-go-modules).  To add Ginkgo to your project, assuming you have a `go.mod` file setup, just `go get` it:
+Ginkgo uses [go modules](https://go.dev/blog/using-go-modules).  To add Ginkgo to your project, assuming you have a `go.mod` file setup, just `go install` it:
 
 ```bash
-go get github.com/onsi/ginkgo/v2/ginkgo
-go get github.com/onsi/gomega/...
+go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+go install -mod=mod github.com/onsi/gomega/...
 ```
 
 This fetches Ginkgo and installs the `ginkgo` executable under `$GOBIN` - you'll want that on your `$PATH`.  It also fetches the core Gomega matcher library and its set of supporting libraries.  Note that the current supported major version of Ginkgo is `v2`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Ginkgo uses [go modules](https://go.dev/blog/using-go-modules).  To add Ginkgo t
 
 ```bash
 go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
-go install -mod=mod github.com/onsi/gomega/...
+go get github.com/onsi/gomega/...
 ```
 
 This fetches Ginkgo and installs the `ginkgo` executable under `$GOBIN` - you'll want that on your `$PATH`.  It also fetches the core Gomega matcher library and its set of supporting libraries.  Note that the current supported major version of Ginkgo is `v2`.


### PR DESCRIPTION
Changes installation instructions to use `go install -mod=mod`, replacing `go get`.

Closes #950