### PR TITLE
Add AddArguments to TableEntry

### DIFF
--- a/table_dsl.go
+++ b/table_dsl.go
@@ -114,6 +114,12 @@ func PEntry(description interface{}, args ...interface{}) TableEntry {
 	return TableEntry{description: description, decorations: decorations, parameters: parameters, codeLocation: types.NewCodeLocation(1)}
 }
 
+func (t *TableEntry) AddArguments(args ...interface{}) {
+	decorations, parameters := internal.PartitionDecorations(args...)
+	t.decorations = append(t.decorations, decorations)
+	t.parameters = append(t.parameters, parameters)
+}
+
 /*
 You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
 */


### PR DESCRIPTION
For usecase like below to reduce repeating arguments
```
for i, _ := range awsTests {
		var entry *TableEntry
		entry = &awsTests[i]
		entry.AddArguments(Label("aws"))
	}
	genericTests = append(genericTests, awsTests...)
```