### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/ginkgo/generators/generate_command.go
+++ b/ginkgo/generators/generate_command.go
@@ -136,8 +136,8 @@ func generateTestFileForSubject(subject string, conf GeneratorsConfig) {
 }
 
 func formatSubject(name string) string {
-	name = strings.Replace(name, "-", "_", -1)
-	name = strings.Replace(name, " ", "_", -1)
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, " ", "_")
 	name = strings.Split(name, ".go")[0]
 	name = strings.Split(name, "_test")[0]
 	return name
@@ -223,7 +223,7 @@ func getPackageImportPath() string {
 	if modRoot != "" {
 		modName := moduleName(modRoot)
 		if modName != "" {
-			cd := strings.Replace(workingDir, modRoot, "", -1)
+			cd := strings.ReplaceAll(workingDir, modRoot, "")
 			cd = strings.ReplaceAll(cd, sep, "/")
 			return modName + cd
 		}

--- a/ginkgo/generators/generators_common.go
+++ b/ginkgo/generators/generators_common.go
@@ -19,8 +19,8 @@ func getPackageAndFormattedName() (string, string, string) {
 	path, err := os.Getwd()
 	command.AbortIfError("Could not get current working directory:", err)
 
-	dirName := strings.Replace(filepath.Base(path), "-", "_", -1)
-	dirName = strings.Replace(dirName, " ", "_", -1)
+	dirName := strings.ReplaceAll(filepath.Base(path), "-", "_")
+	dirName = strings.ReplaceAll(dirName, " ", "_")
 
 	pkg, err := build.ImportDir(path, 0)
 	packageName := pkg.Name
@@ -47,10 +47,10 @@ func ensureLegalPackageName(name string) string {
 }
 
 func prettifyName(name string) string {
-	name = strings.Replace(name, "-", " ", -1)
-	name = strings.Replace(name, "_", " ", -1)
+	name = strings.ReplaceAll(name, "-", " ")
+	name = strings.ReplaceAll(name, "_", " ")
 	name = strings.Title(name)
-	name = strings.Replace(name, " ", "", -1)
+	name = strings.ReplaceAll(name, " ", "")
 	return name
 }
 

--- a/ginkgo/internal/run.go
+++ b/ginkgo/internal/run.go
@@ -330,8 +330,8 @@ func runAfterRunHook(command string, noColor bool, suite TestSuite) {
 	if suite.State.Is(TestSuiteStatePassed) {
 		passed = "[PASS]"
 	}
-	command = strings.Replace(command, "(ginkgo-suite-passed)", passed, -1)
-	command = strings.Replace(command, "(ginkgo-suite-name)", suite.PackageName, -1)
+	command = strings.ReplaceAll(command, "(ginkgo-suite-passed)", passed)
+	command = strings.ReplaceAll(command, "(ginkgo-suite-name)", suite.PackageName)
 
 	// Must break command into parts
 	splitArgs := regexp.MustCompile(`'.+'|".+"|\S+`)

--- a/reporters/teamcity_report.go
+++ b/reporters/teamcity_report.go
@@ -17,12 +17,12 @@ import (
 )
 
 func tcEscape(s string) string {
-	s = strings.Replace(s, "|", "||", -1)
-	s = strings.Replace(s, "'", "|'", -1)
-	s = strings.Replace(s, "\n", "|n", -1)
-	s = strings.Replace(s, "\r", "|r", -1)
-	s = strings.Replace(s, "[", "|[", -1)
-	s = strings.Replace(s, "]", "|]", -1)
+	s = strings.ReplaceAll(s, "|", "||")
+	s = strings.ReplaceAll(s, "'", "|'")
+	s = strings.ReplaceAll(s, "\n", "|n")
+	s = strings.ReplaceAll(s, "\r", "|r")
+	s = strings.ReplaceAll(s, "[", "|[")
+	s = strings.ReplaceAll(s, "]", "|]")
 	return s
 }
 


### PR DESCRIPTION
Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.