### PR TITLE
TrimRight is not designed to trim Suffix

### DIFF
--- a/integration/profiling_test.go
+++ b/integration/profiling_test.go
@@ -54,7 +54,7 @@ func ParseProfile(binary string, path string) ProfileLines {
 		var cumStat float64
 		if strings.Contains(cumStatEntry, "MB") {
 			var err error
-			cumStat, err = strconv.ParseFloat(strings.TrimRight(cumStatEntry, "MB"), 64)
+			cumStat, err = strconv.ParseFloat(strings.TrimSuffix(cumStatEntry, "MB"), 64)
 			ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 		} else {
 			duration, err := time.ParseDuration(cumStatEntry)


### PR DESCRIPTION
See: https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/strings/strings.go;l=894

> // To remove a suffix, use TrimSuffix instead.