### PR TITLE
Exit if error: describeTable with no parameters

### DIFF
--- a/table_dsl.go
+++ b/table_dsl.go
@@ -135,6 +135,10 @@ func generateTable(description string, args ...interface{}) {
 		return "Entry: " + strings.Join(out, ", ")
 	}
 
+	if len(args) == 1 {
+		exitIfErr(types.GinkgoErrors.MissingParametersForTableFunction(cl))
+	}
+
 	for i, arg := range args {
 		switch t := reflect.TypeOf(arg); {
 		case t == nil:

--- a/types/errors.go
+++ b/types/errors.go
@@ -380,6 +380,15 @@ func (g ginkgoErrors) InvalidEntryDescription(cl CodeLocation) error {
 	}
 }
 
+func (g ginkgoErrors) MissingParametersForTableFunction(cl CodeLocation) error {
+	return GinkgoError{
+		Heading:      fmt.Sprintf("No parameters have been passed to the Table Function"),
+		Message:      fmt.Sprintf("The Table Function expected at least 1 parameter"),
+		CodeLocation: cl,
+		DocLink:      "table-specs",
+	}
+}
+
 func (g ginkgoErrors) IncorrectParameterTypeForTable(i int, name string, cl CodeLocation) error {
 	return GinkgoError{
 		Heading:      "DescribeTable passed incorrect parameter type",


### PR DESCRIPTION
Fix: https://github.com/onsi/ginkgo/issues/1029
[Backlog Item #183159888](https://www.pivotaltracker.com/story/show/183159888)

Proposal is to add validation of the length of the arguments passed to the DescribeTable function prior to any validation of the arguments itself.

There were no tests on equivalent DescribeTable errors (i.e.: MultipleEntryBodyFunctionsForTable and InvalidEntryDescription). I don't know if there's any history there or not, but following convention, I also did not add tests for this new error. I'll gladly take comments on that decision.

No document updates were made since this simply reflects current expected behaviour.