### PR TITLE
Add support to customize junit report config to omit spec labels

### DIFF
--- a/reporters/junit_report.go
+++ b/reporters/junit_report.go
@@ -30,6 +30,9 @@ type JunitReportConfig struct {
 
 	//Enable OmitCapturedStdOutErr to prevent captured stdout/stderr appearing in system-out
 	OmitCapturedStdOutErr bool
+
+	// Enable OmitSpecLabels to prevent labels from appearing in the spec name
+	OmitSpecLabels bool
 }
 
 type JUnitTestSuites struct {
@@ -176,7 +179,7 @@ func GenerateJUnitReportWithConfig(report types.Report, dst string, config Junit
 			name = name + " " + spec.FullText()
 		}
 		labels := spec.Labels()
-		if len(labels) > 0 {
+		if len(labels) > 0 && !config.OmitSpecLabels {
 			name = name + " [" + strings.Join(labels, ", ") + "]"
 		}
 

--- a/reporters/junit_report_test.go
+++ b/reporters/junit_report_test.go
@@ -219,6 +219,7 @@ var _ = Describe("JunitReport", func() {
 				OmitTimelinesForSpecState: types.SpecStatePassed,
 				OmitFailureMessageAttr:    true,
 				OmitCapturedStdOutErr:     true,
+				OmitSpecLabels:            true,
 			})).Should(Succeed())
 			DeferCleanup(os.Remove, fname)
 
@@ -251,7 +252,7 @@ var _ = Describe("JunitReport", func() {
 			Ω(suite.TestCases).Should(HaveLen(4))
 
 			failingSpec := suite.TestCases[0]
-			Ω(failingSpec.Name).Should(Equal("[It] A B C [dolphin, gorilla, cow, cat, dog]"))
+			Ω(failingSpec.Name).Should(Equal("[It] A B C"))
 			Ω(failingSpec.Classname).Should(Equal("My Suite"))
 			Ω(failingSpec.Status).Should(Equal("timedout"))
 			Ω(failingSpec.Skipped).Should(BeNil())


### PR DESCRIPTION
# Change

Ginkgo tests that generate JUnit XML report may wish to omit labels from appearing within the spec. This is helpful when these results get imported into third party applications for analyzing/displaying test results. This commit adds a new field to the JunitReportConfig to be able to omit labels from being included within a spec. By default, labels will be included in the spec within the junit xml report (current behavior). Users can override this based on their needs.

# Verification

```go
package main

import (
	"testing"

	. "github.com/onsi/ginkgo/v2"
	"github.com/onsi/ginkgo/v2/reporters"
	. "github.com/onsi/gomega"
)

func TestPR(t *testing.T) {
	ReportAfterSuite("Test PR", func(report Report) {
		reporters.GenerateJUnitReportWithConfig(
			report,
			"test.xml",
			reporters.JunitReportConfig{OmitSpecLabels: true},
		)
	})

	RegisterFailHandler(Fail)
	RunSpecs(t, "Test PR", Label("pr-test"))
}

var _ = Describe("String comparison", func() {
	It("should be equal", Label("pr-test"), func() {
		Expect("apple").To(Equal("apple"))
	})
})
```

```
cat test.xml | grep testcase
          <testcase name="[It] String comparison should be equal" classname="Test PR" status="passed" time="0.0001772">
          </testcase>
```