### PR TITLE
Add junit config option for omitting leafnodetype

### DIFF
--- a/reporters/junit_report.go
+++ b/reporters/junit_report.go
@@ -33,6 +33,9 @@ type JunitReportConfig struct {
 
 	// Enable OmitSpecLabels to prevent labels from appearing in the spec name
 	OmitSpecLabels bool
+
+	// Enable OmitLeafNodeType to prevent the spec leaf node type from appearing in the spec name
+	OmitLeafNodeType bool
 }
 
 type JUnitTestSuites struct {
@@ -175,6 +178,9 @@ func GenerateJUnitReportWithConfig(report types.Report, dst string, config Junit
 	}
 	for _, spec := range report.SpecReports {
 		name := fmt.Sprintf("[%s]", spec.LeafNodeType)
+		if config.OmitLeafNodeType {
+			name = ""
+		}
 		if spec.FullText() != "" {
 			name = name + " " + spec.FullText()
 		}
@@ -182,6 +188,7 @@ func GenerateJUnitReportWithConfig(report types.Report, dst string, config Junit
 		if len(labels) > 0 && !config.OmitSpecLabels {
 			name = name + " [" + strings.Join(labels, ", ") + "]"
 		}
+		name = strings.TrimSpace(name)
 
 		test := JUnitTestCase{
 			Name:      name,

--- a/reporters/junit_report_test.go
+++ b/reporters/junit_report_test.go
@@ -220,6 +220,7 @@ var _ = Describe("JunitReport", func() {
 				OmitFailureMessageAttr:    true,
 				OmitCapturedStdOutErr:     true,
 				OmitSpecLabels:            true,
+				OmitLeafNodeType:          true,
 			})).Should(Succeed())
 			DeferCleanup(os.Remove, fname)
 
@@ -252,7 +253,7 @@ var _ = Describe("JunitReport", func() {
 			Ω(suite.TestCases).Should(HaveLen(4))
 
 			failingSpec := suite.TestCases[0]
-			Ω(failingSpec.Name).Should(Equal("[It] A B C"))
+			Ω(failingSpec.Name).Should(Equal("A B C"))
 			Ω(failingSpec.Classname).Should(Equal("My Suite"))
 			Ω(failingSpec.Status).Should(Equal("timedout"))
 			Ω(failingSpec.Skipped).Should(BeNil())
@@ -303,7 +304,7 @@ var _ = Describe("JunitReport", func() {
 			))
 
 			passingSpec := suite.TestCases[1]
-			Ω(passingSpec.Name).Should(Equal("[It] A"))
+			Ω(passingSpec.Name).Should(Equal("A"))
 			Ω(passingSpec.Classname).Should(Equal("My Suite"))
 			Ω(passingSpec.Status).Should(Equal("passed"))
 			Ω(passingSpec.Skipped).Should(BeNil())
@@ -313,7 +314,7 @@ var _ = Describe("JunitReport", func() {
 			Ω(passingSpec.SystemErr).Should(BeEmpty())
 
 			pendingSpec := suite.TestCases[2]
-			Ω(pendingSpec.Name).Should(Equal("[It] A"))
+			Ω(pendingSpec.Name).Should(Equal("A"))
 			Ω(pendingSpec.Classname).Should(Equal("My Suite"))
 			Ω(pendingSpec.Status).Should(Equal("pending"))
 			Ω(pendingSpec.Skipped.Message).Should(Equal("pending"))
@@ -323,7 +324,7 @@ var _ = Describe("JunitReport", func() {
 			Ω(pendingSpec.SystemErr).Should(BeEmpty())
 
 			panickedSpec := suite.TestCases[3]
-			Ω(panickedSpec.Name).Should(Equal("[It] A"))
+			Ω(panickedSpec.Name).Should(Equal("A"))
 			Ω(panickedSpec.Classname).Should(Equal("My Suite"))
 			Ω(panickedSpec.Status).Should(Equal("panicked"))
 			Ω(panickedSpec.Skipped).Should(BeNil())


### PR DESCRIPTION
similarly to de44005, users may also want to omit the LeafNodeType

allow omitting the LeafNodeType (`[It]`) from being included in the
junit results file by adding a new config option and skipping over the
setting of name to LeafNodeType. Default behavior remains as is.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

```go
package ginkgo

import (
    "testing"

    "github.com/onsi/ginkgo/v2/reporters"
    . "github.com/onsi/gomega"
)

func TestPR(t *testing.T) {
    ReportAfterSuite("Test PR", func(report Report) {
        reporters.GenerateJUnitReportWithConfig(
            report,
            "test.xml",
            reporters.JunitReportConfig{OmitLeafNodeType: true},
        )
    })

    RegisterFailHandler(Fail)
    RunSpecs(t, "Test PR", Label("pr-test"))
}

var _ = Describe("String comparison", func() {
    It("should be equal", Label("pr-test"), func() {
        Expect("apple").To(Equal("apple"))
    })
})
```

```
❯ cat test.xml | grep testcase
          <testcase name="String comparison should be equal [pr-test]" classname="Test PR" status="skipped" time="0">
          </testcase>
```
