### PR TITLE
Override environment formatter colors from envvars

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -50,6 +50,15 @@ func NewWithNoColorBool(noColor bool) Formatter {
 }
 
 func New(colorMode ColorMode) Formatter {
+	getColor := func(color, defaultEscapeCode string) string {
+		color = strings.ToUpper(strings.ReplaceAll(color, "-", "_"))
+		envVar := fmt.Sprintf("GINKGO_CLI_COLOR_%s", color)
+		if escapeCode := os.Getenv(envVar); escapeCode != "" {
+			return escapeCode
+		}
+		return defaultEscapeCode
+	}
+
 	f := Formatter{
 		ColorMode: colorMode,
 		colors: map[string]string{
@@ -57,18 +66,18 @@ func New(colorMode ColorMode) Formatter {
 			"bold":      "\x1b[1m",
 			"underline": "\x1b[4m",
 
-			"red":          "\x1b[38;5;9m",
-			"orange":       "\x1b[38;5;214m",
-			"coral":        "\x1b[38;5;204m",
-			"magenta":      "\x1b[38;5;13m",
-			"green":        "\x1b[38;5;10m",
-			"dark-green":   "\x1b[38;5;28m",
-			"yellow":       "\x1b[38;5;11m",
-			"light-yellow": "\x1b[38;5;228m",
-			"cyan":         "\x1b[38;5;14m",
-			"gray":         "\x1b[38;5;243m",
-			"light-gray":   "\x1b[38;5;246m",
-			"blue":         "\x1b[38;5;12m",
+			"red":          getColor("red", "\x1b[38;5;9m"),
+			"orange":       getColor("orange", "\x1b[38;5;214m"),
+			"coral":        getColor("coral", "\x1b[38;5;204m"),
+			"magenta":      getColor("magenta", "\x1b[38;5;13m"),
+			"green":        getColor("green", "\x1b[38;5;10m"),
+			"dark-green":   getColor("darkgreen", "\x1b[38;5;28m"),
+			"yellow":       getColor("yellow", "\x1b[38;5;11m"),
+			"light-yellow": getColor("light-yellow", "\x1b[38;5;228m"),
+			"cyan":         getColor("cyan", "\x1b[38;5;14m"),
+			"gray":         getColor("gray", "\x1b[38;5;243m"),
+			"light-gray":   getColor("light-gray", "\x1b[38;5;246m"),
+			"blue":         getColor("blue", "\x1b[38;5;12m"),
 		},
 	}
 	colors := []string{}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,6 +1,7 @@
 package formatter_test
 
 import (
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,6 +48,20 @@ var _ = Describe("Formatter", func() {
 
 		It("leaves the color information as is, allowing us to test statements more easily", func() {
 			Ω(f.F("{{green}}{{bold}}hi there{{/}}")).Should(Equal("{{green}}{{bold}}hi there{{/}}"))
+		})
+	})
+
+	Context("with environment overrides", func() {
+		BeforeEach(func() {
+			os.Setenv("GINKGO_CLI_COLOR_RED", "\x1b[31m")
+		})
+
+		It("uses the escape codes from the environment variables", func() {
+			Ω(f.F("{{red}}hi there{{/}}")).Should(Equal("\x1b[31mhi there\x1b[0m"))
+		})
+
+		AfterEach(func() {
+			os.Unsetenv("GINKGO_CLI_COLOR_RED")
 		})
 	})
 


### PR DESCRIPTION
This allows a user to set environment variables
`GINKGO_CLI_COLOR_<color>` with asci code overrides. This helps a lot when the colorscheme that you are using doesn't play well with the colors from the 256 color scheme which currently is hard coded.

Example `GINKGO_CLI_COLOR_RED=$'\x1b[31m' ginkgo` will use the red from the 8bit colors configured in the terminal.