### PR TITLE
Ensure go test coverprofile outputs to the expected location

### DIFF
--- a/ginkgo/internal/run.go
+++ b/ginkgo/internal/run.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -63,6 +64,12 @@ func checkForNoTestsWarning(buf *bytes.Buffer) bool {
 }
 
 func runGoTest(suite TestSuite, cliConfig types.CLIConfig, goFlagsConfig types.GoFlagsConfig) TestSuite {
+	// As we run the go test from the suite directory, make sure the cover profile is absolute
+	// and placed into the expected output directory when one is configured.
+	if goFlagsConfig.Cover && !filepath.IsAbs(goFlagsConfig.CoverProfile) {
+		goFlagsConfig.CoverProfile = AbsPathForGeneratedAsset(goFlagsConfig.CoverProfile, suite, cliConfig, 0)
+	}
+
 	args, err := types.GenerateGoTestRunArgs(goFlagsConfig)
 	command.AbortIfError("Failed to generate test run arguments", err)
 	cmd, buf := buildAndStartCommand(suite, args, true)


### PR DESCRIPTION
Fixes #1104 

This PR updates the `runGoTest` function to set the coverprofile to the `AbsPathForGeneratedAsset` when the coverprofile isn't already absolute (that seems sensible but I note that isn't the case for the `runSerial` function just below which has the same sort of fix?)

This should resolve the issue described, where the coverprofile ends up in the test suite dir.

When `outputDir` is not set, the `AbsPathForGeneratedAsset` sets the output to the suite's abs path plus the asset name, which is the behaviour right now.

When `outputDir` is set, it sets the path to the suite name plus asset name within the output dir. This uses the same logic as is used within the finalize section so should mean things like the keep separate reports and output vs output should behave correctly.

Testing locally, if I have no `outputDir`, each suite gets their own coverprofile (both Go and ginkgo suites), if I have an `outputDir`, the error is gone and I get a single profile out which I believe is expected`, combining that with `-keep-separate-coverprofiles` gives me a folder of individual coverprofiles based on the suite names.