### PR TITLE
fix generators link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5233,7 +5233,7 @@ with a JSON file
 The custom data can be accessed like so:
 `{{ .CustomData.suitename }}` or `{{ range .CustomData.labels }} {{.}} {{ end }}`
 
-Take a look at the [Ginkgo's CLI code](https://github.com/onsi/ginkgo/tree/master/ginkgo/ginkgo/generators) to see what's available in the template.
+Take a look at the [Ginkgo's CLI code](https://github.com/onsi/ginkgo/tree/master/ginkgo/generators) to see what's available in the template.
 
 ### Creating an Outline of Specs
 


### PR DESCRIPTION
pointing to a 404 due to the extra `ginkgo`

https://onsi.github.io/ginkgo/#generators clicking the link at the bottom of this section results in a 404