### PR TITLE
feat(ginkgo/generators): add --tags flag

### DIFF
--- a/ginkgo/generators/generate_command.go
+++ b/ginkgo/generators/generate_command.go
@@ -32,6 +32,9 @@ func BuildGenerateCommand() command.Command {
 			{Name: "template-data", KeyPath: "CustomTemplateData",
 				UsageArgument: "template-data-file",
 				Usage:         "If specified, generate will use the contents of the file passed as data to be rendered in the test file template"},
+			{Name: "tags", KeyPath: "Tags",
+				UsageArgument: "build-tags",
+				Usage:         "If specified, generate will create a test file that uses the given build tags (i.e. `--tags e2e,!unit` will add `//go:build e2e,!unit`)"},
 		},
 		&conf,
 		types.GinkgoFlagSections{},
@@ -59,6 +62,7 @@ You can also pass a <filename> of the form "file.go" and generate will emit "fil
 }
 
 type specData struct {
+	BuildTags         string
 	Package           string
 	Subject           string
 	PackageImportPath string
@@ -93,6 +97,7 @@ func generateTestFileForSubject(subject string, conf GeneratorsConfig) {
 	}
 
 	data := specData{
+		BuildTags:         getBuildTags(conf.Tags),
 		Package:           determinePackageName(packageName, conf.Internal),
 		Subject:           formattedName,
 		PackageImportPath: getPackageImportPath(),

--- a/ginkgo/generators/generate_templates.go
+++ b/ginkgo/generators/generate_templates.go
@@ -1,6 +1,7 @@
 package generators
 
-var specText = `package {{.Package}}
+var specText = `{{.BuildTags}}
+package {{.Package}}
 
 import (
 	{{.GinkgoImport}}
@@ -14,7 +15,8 @@ var _ = {{.GinkgoPackage}}Describe("{{.Subject}}", func() {
 })
 `
 
-var agoutiSpecText = `package {{.Package}}
+var agoutiSpecText = `{{.BuildTags}}
+package {{.Package}}
 
 import (
 	{{.GinkgoImport}}

--- a/ginkgo/generators/generators_common.go
+++ b/ginkgo/generators/generators_common.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"fmt"
 	"go/build"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ type GeneratorsConfig struct {
 	Agouti, NoDot, Internal bool
 	CustomTemplate          string
 	CustomTemplateData      string
+	Tags                    string
 }
 
 func getPackageAndFormattedName() (string, string, string) {
@@ -61,4 +63,14 @@ func determinePackageName(name string, internal bool) string {
 	}
 
 	return name + "_test"
+}
+
+// getBuildTags returns the resultant string to be added.
+// If the input string is not empty, then returns a `//go:build {}` string,
+// otherwise returns an empty string.
+func getBuildTags(tags string) string {
+	if tags != "" {
+		return fmt.Sprintf("//go:build %s\n", tags)
+	}
+	return ""
 }


### PR DESCRIPTION
This PR adds a new flag `--tags` under the `ginkgo generate` command.
This flag allows the user to add the build tags that he needs for the tests.

Closes #1213 

Example command:
```
ginkgo generate -tags "unit || e2e" test
```

This will generate the following file:
```golang
//go:build unit || e2e

package main_test

import (
	. "github.com/onsi/ginkgo/v2"
	. "github.com/onsi/gomega"

	"github.com/onsi/ginkgo/v2/ginkgo"
)

var _ = Describe("Test", func() {

})

```