### PR TITLE
Fix broken link in MIGRATING_TO_V2.md

### DIFF
--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -391,7 +391,7 @@ Ginkgo can now repeat a test suite N additional times by running `ginkgo --repea
 Ginkgo requires the tests to succeed during each repetition in order to consider the test run a success.
 
 ### New: --focus-file and --skip-file
-You can now tell Ginkgo to only run specs that match (or don't match) a given file filter.  You can filter by filename as well as file:line.  See the [Filtering Specs](onsi.github.io/ginkgo/#filtering-specs) documentation for more details.
+You can now tell Ginkgo to only run specs that match (or don't match) a given file filter.  You can filter by filename as well as file:line.  See the [Filtering Specs](https://onsi.github.io/ginkgo/#filtering-specs) documentation for more details.
 
 ### Improved: windows support for capturing stdout and stderr
 In V1 Ginkgo would run windows tests in parallel with the `--stream` option.  This would result in hard-to-understand interleaved output.  The reason behind this design choice was that it proved challenging to intercept all stdout and stderr output on Windows.  V2 implements a best-effort output interception scheme for windows that entails reassigning the global `os.Stdout` and `os.Stderr` variables.  While not as bullet-proof as the Unix `syscall.Dup2` based implementation, this is likely good enough for most usecases and allows Ginkgo support on Windows to come into parity with unix.


### PR DESCRIPTION
Got 404 error when click on the link
![image](https://github.com/onsi/ginkgo/assets/10071833/65f071c9-4285-49b5-848c-727ffff729f8)
