### PR TITLE
chore: update test matrix for Go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.19'
+        go-version: '1.20'
     - uses: actions/checkout@v3
     - run: go mod tidy && git diff --exit-code go.mod go.sum
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.19', '1.20' ]
+        version: [ '1.20', '1.21' ]
     name: Go ${{ matrix.version }}
     steps:
     - uses: actions/setup-go@v4


### PR DESCRIPTION
Go 1.21 has just been released.
Implicitly, Go 1.19 is now out of support.