### PR TITLE
feat: allow MustPassRepeatedly decorator to be set at suite level

### DIFF
--- a/integration/_fixtures/config_override_label_filter_fixture/config_override_fixture_suite_test.go
+++ b/integration/_fixtures/config_override_label_filter_fixture/config_override_fixture_suite_test.go
@@ -1,4 +1,4 @@
-package config_override_fixture_test
+package config_override_label_filter_fixture_test
 
 import (
 	"testing"

--- a/integration/_fixtures/config_override_must_pass_repeatedly_fixture/config_override_fixture_suite_test.go
+++ b/integration/_fixtures/config_override_must_pass_repeatedly_fixture/config_override_fixture_suite_test.go
@@ -1,0 +1,21 @@
+package config_override_label_filter_fixture_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigOverrideFixture(t *testing.T) {
+	RegisterFailHandler(Fail)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	suiteConfig.MustPassRepeatedly = 10
+	RunSpecs(t, "ConfigOverrideFixture Suite", suiteConfig, reporterConfig)
+}
+
+var _ = Describe("tests", func() {
+	It("suite config overrides decorator", MustPassRepeatedly(2), func() {
+		Ω(CurrentSpecReport().MaxMustPassRepeatedly).Should(Equal(10))
+	})
+})

--- a/integration/flags_test.go
+++ b/integration/flags_test.go
@@ -135,8 +135,8 @@ var _ = Describe("Flags Specs", func() {
 	})
 
 	It("should allow configuration overrides", func() {
-		fm.MountFixture("config_override")
-		session := startGinkgo(fm.PathTo("config_override"), "--label-filter=NORUN", "--no-color")
+		fm.MountFixture("config_override_label_filter")
+		session := startGinkgo(fm.PathTo("config_override_label_filter"), "--label-filter=NORUN", "--no-color")
 		Eventually(session).Should(gexec.Exit(0), "Succeeds because --label-filter is overridden by the test suite itself.")
 		output := string(session.Out.Contents())
 		Ω(output).Should(ContainSubstring("2 Specs"))

--- a/integration/repeat_test.go
+++ b/integration/repeat_test.go
@@ -98,4 +98,15 @@ var _ = Describe("Repeat", func() {
 			Ω(session.Err).Should(gbytes.Say("--repeat and --until-it-fails are both set"))
 		})
 	})
+
+	Context("if MustPassRepeatedly is set at suite config level", func() {
+		BeforeEach(func() {
+			fm.MountFixture("config_override_must_pass_repeatedly")
+		})
+
+		It("it should override node decorator", func() {
+			session := startGinkgo(fm.PathTo("config_override_must_pass_repeatedly"))
+			Eventually(session).Should(gexec.Exit(0))
+		})
+	})
 })

--- a/internal/group.go
+++ b/internal/group.go
@@ -321,7 +321,10 @@ func (g *group) run(specs Specs) {
 		if !skip {
 			var maxAttempts = 1
 
-			if g.suite.currentSpecReport.MaxMustPassRepeatedly > 0 {
+			if g.suite.config.MustPassRepeatedly > 0 {
+				maxAttempts = g.suite.config.MustPassRepeatedly
+				g.suite.currentSpecReport.MaxMustPassRepeatedly = maxAttempts
+			} else if g.suite.currentSpecReport.MaxMustPassRepeatedly > 0 {
 				maxAttempts = max(1, spec.MustPassRepeatedly())
 			} else if g.suite.config.FlakeAttempts > 0 {
 				maxAttempts = g.suite.config.FlakeAttempts

--- a/internal/internal_integration/config_must_pass_repeatedly_test.go
+++ b/internal/internal_integration/config_must_pass_repeatedly_test.go
@@ -1,0 +1,57 @@
+package internal_integration_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2/internal/test_helpers"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("when config.MustPassRepeatedly is greater than 1", func() {
+	var success bool
+	JustBeforeEach(func() {
+		var counterB int
+		success, _ = RunFixture("flakey success", func() {
+			It("A", func() {})
+			It("B", func() {
+				counterB += 1
+				if counterB == 8 {
+					F(fmt.Sprintf("C - %d", counterB))
+				}
+			})
+		})
+	})
+
+	Context("when all tests pass", func() {
+		BeforeEach(func() {
+			conf.MustPassRepeatedly = 5
+		})
+
+		It("reports that the suite passed", func() {
+			Ω(success).Should(BeTrue())
+			Ω(reporter.End).Should(BeASuiteSummary(NSpecs(2), NFailed(0), NPassed(2)))
+		})
+
+		It("reports that the tests passed with the correct number of attempts", func() {
+			Ω(reporter.Did.Find("A")).Should(HavePassed(NumAttempts(5)))
+			Ω(reporter.Did.Find("B")).Should(HavePassed(NumAttempts(5)))
+		})
+	})
+
+	Context("when a test fails", func() {
+		BeforeEach(func() {
+			conf.MustPassRepeatedly = 10
+		})
+
+		It("reports that the suite failed", func() {
+			Ω(success).Should(BeFalse())
+			Ω(reporter.End).Should(BeASuiteSummary(NSpecs(2), NFailed(1), NPassed(1)))
+		})
+
+		It("reports that the tests failed with the correct number of attempts", func() {
+			Ω(reporter.Did.Find("A")).Should(HavePassed(NumAttempts(10)))
+			Ω(reporter.Did.Find("B")).Should(HaveFailed(NumAttempts(8)))
+		})
+	})
+})

--- a/types/config.go
+++ b/types/config.go
@@ -27,6 +27,7 @@ type SuiteConfig struct {
 	FailOnPending         bool
 	FailFast              bool
 	FlakeAttempts         int
+	MustPassRepeatedly    int
 	DryRun                bool
 	PollProgressAfter     time.Duration
 	PollProgressInterval  time.Duration


### PR DESCRIPTION
Relates to https://github.com/onsi/ginkgo/issues/1265

Aims to allow `MustPassRepeatedly` to be set at suite level programatically, similarly of `FlakeAttempts`. 