### PR TITLE
# 1296 fix(precompiled test guite): exec bit check omitted on Windows

### DIFF
--- a/ginkgo/internal/test_suite.go
+++ b/ginkgo/internal/test_suite.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2/types"
@@ -192,7 +193,7 @@ func precompiledTestSuite(path string) (TestSuite, error) {
 		return TestSuite{}, errors.New("this is not a .test binary")
 	}
 
-	if filepath.Ext(path) == ".test" && info.Mode()&0111 == 0 {
+	if filepath.Ext(path) == ".test" && runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
 		return TestSuite{}, errors.New("this is not executable")
 	}
 


### PR DESCRIPTION
Tested on Windows (21H2) and Linux (Mint 21):
- manual tests were successful
- some perf-related automated tests failed on both Windows and Linux **before** I did any changes. These tests seem to be unrelated to this scope here anyways.