### PR TITLE
Avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/ginkgo/internal/test_suite.go
+++ b/ginkgo/internal/test_suite.go
@@ -226,7 +226,7 @@ func suitesInDir(dir string, recurse bool) TestSuites {
 	files, _ := os.ReadDir(dir)
 	re := regexp.MustCompile(`^[^._].*_test\.go$`)
 	for _, file := range files {
-		if !file.IsDir() && re.Match([]byte(file.Name())) {
+		if !file.IsDir() && re.MatchString(file.Name()) {
 			suite := TestSuite{
 				Path:        relPath(dir),
 				PackageName: packageNameForSuite(dir),
@@ -241,7 +241,7 @@ func suitesInDir(dir string, recurse bool) TestSuites {
 	if recurse {
 		re = regexp.MustCompile(`^[._]`)
 		for _, file := range files {
-			if file.IsDir() && !re.Match([]byte(file.Name())) {
+			if file.IsDir() && !re.MatchString(file.Name()) {
 				suites = append(suites, suitesInDir(dir+"/"+file.Name(), recurse)...)
 			}
 		}
@@ -272,7 +272,7 @@ func filesHaveGinkgoSuite(dir string, files []os.DirEntry) bool {
 	reGinkgo := regexp.MustCompile(`package ginkgo|\/ginkgo"|\/ginkgo\/v2"|\/ginkgo\/v2/dsl/`)
 
 	for _, file := range files {
-		if !file.IsDir() && reTestFile.Match([]byte(file.Name())) {
+		if !file.IsDir() && reTestFile.MatchString(file.Name()) {
 			contents, _ := os.ReadFile(dir + "/" + file.Name())
 			if reGinkgo.Match(contents) {
 				return true

--- a/ginkgo/watch/dependencies.go
+++ b/ginkgo/watch/dependencies.go
@@ -78,7 +78,7 @@ func (d Dependencies) resolveAndAdd(deps []string, depth int) {
 		if err != nil {
 			continue
 		}
-		if !pkg.Goroot && (!ginkgoAndGomegaFilter.Match([]byte(pkg.Dir)) || ginkgoIntegrationTestFilter.Match([]byte(pkg.Dir))) {
+		if !pkg.Goroot && (!ginkgoAndGomegaFilter.MatchString(pkg.Dir) || ginkgoIntegrationTestFilter.MatchString(pkg.Dir)) {
 			d.addDepIfNotPresent(pkg.Dir, depth)
 		}
 	}

--- a/ginkgo/watch/package_hash.go
+++ b/ginkgo/watch/package_hash.go
@@ -79,7 +79,7 @@ func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Ti
 			continue
 		}
 
-		if goTestRegExp.Match([]byte(info.Name())) {
+		if goTestRegExp.MatchString(info.Name()) {
 			testHash += p.hashForFileInfo(info)
 			if info.ModTime().After(testModifiedTime) {
 				testModifiedTime = info.ModTime()
@@ -87,7 +87,7 @@ func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Ti
 			continue
 		}
 
-		if p.watchRegExp.Match([]byte(info.Name())) {
+		if p.watchRegExp.MatchString(info.Name()) {
 			codeHash += p.hashForFileInfo(info)
 			if info.ModTime().After(codeModifiedTime) {
 				codeModifiedTime = info.ModTime()

--- a/types/code_location.go
+++ b/types/code_location.go
@@ -149,7 +149,7 @@ func PruneStack(fullStackTrace string, skip int) string {
 		re := regexp.MustCompile(`\/ginkgo\/|\/pkg\/testing\/|\/pkg\/runtime\/`)
 		for i := 0; i < len(stack)/2; i++ {
 			// We filter out based on the source code file name.
-			if !re.Match([]byte(stack[i*2+1])) {
+			if !re.MatchString(stack[i*2+1]) {
 				prunedStack = append(prunedStack, stack[i*2])
 				prunedStack = append(prunedStack, stack[i*2+1])
 			}


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
var goTestRegExp = regexp.MustCompile(`_test\.go$`)

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := goTestRegExp.Match([]byte("file_test.go")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := goTestRegExp.MatchString("file_test.go"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/onsi/ginkgo/v2/ginkgo/watch
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 5665784	       314.4 ns/op	      16 B/op	       1 allocs/op
BenchmarkMatchString-16    	 8481872	       140.5 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/onsi/ginkgo/v2/ginkgo/watch	4.321s
```