### PR TITLE
Fix typo in internal/suite.go

### DIFF
--- a/internal/suite.go
+++ b/internal/suite.go
@@ -79,7 +79,7 @@ func NewSuite() *Suite {
 
 func (suite *Suite) Clone() (*Suite, error) {
 	if suite.phase != PhaseBuildTopLevel {
-		return nil, fmt.Errorf("cnanot clone suite after tree has been built")
+		return nil, fmt.Errorf("cannot clone suite after tree has been built")
 	}
 	return &Suite{
 		tree:                    &TreeNode{},

--- a/internal/suite_test.go
+++ b/internal/suite_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Suite", func() {
 			It("fails if the tree has already been built", func() {
 				Ω(suite.BuildTree()).Should(Succeed())
 				_, err := suite.Clone()
-				Ω(err).Should(MatchError("cnanot clone suite after tree has been built"))
+				Ω(err).Should(MatchError("cannot clone suite after tree has been built"))
 			})
 
 			It("generates the same tree as the original", func() {


### PR DESCRIPTION
I saw this error message with a small spelling mistake while writing tests. 
```
cnanot clone suite after tree has been built
```
This PR fixes the same.