### PR TITLE
bugfix(docs): use Unsetenv instead of Clearenv

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -875,7 +875,7 @@ Describe("Reporting book weight", func() {
 
   Context("with no WEIGHT_UNITS environment set", func() {
     BeforeEach(func() {
-      err := os.Clearenv("WEIGHT_UNITS")
+      err := os.Unsetenv("WEIGHT_UNITS")
       Expect(err).NotTo(HaveOccurred())
     })
 
@@ -928,13 +928,13 @@ Describe("Reporting book weight", func() {
   })
 
   AfterEach(func() {
-    err := os.Clearenv("WEIGHT_UNITS")
+    err := os.Unsetenv("WEIGHT_UNITS")
     Expect(err).NotTo(HaveOccurred())
   })
 
   Context("with no WEIGHT_UNITS environment set", func() {
     BeforeEach(func() {
-      err := os.Clearenv("WEIGHT_UNITS")
+      err := os.Unsetenv("WEIGHT_UNITS")
       Expect(err).NotTo(HaveOccurred())
     })
 


### PR DESCRIPTION
The documentation incorrectly uses `os.Clearenv` to clear specific environment variables. In fact, we should use `os.Unsetenv`.

The APIs related to these two functions are as follows:

https://pkg.go.dev/os#Clearenv
https://pkg.go.dev/os#Unsetenv