### PR TITLE
merge coverages instead of combining them (#1329)

### DIFF
--- a/ginkgo/internal/gocovmerge.go
+++ b/ginkgo/internal/gocovmerge.go
@@ -1,5 +1,29 @@
+// Copyright (c) 2015, Wade Simmons
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 // Package gocovmerge takes the results from multiple `go test -coverprofile`
 // runs and merges them into one profile
+
 // this file was originally taken from the gocovmerge project
 // see also: https://go.shabbyrobe.org/gocovmerge
 package internal

--- a/ginkgo/internal/gocovmerge.go
+++ b/ginkgo/internal/gocovmerge.go
@@ -1,0 +1,105 @@
+// Package gocovmerge takes the results from multiple `go test -coverprofile`
+// runs and merges them into one profile
+// this file was originally taken from the gocovmerge project
+// see also: https://go.shabbyrobe.org/gocovmerge
+package internal
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"golang.org/x/tools/cover"
+)
+
+func AddCoverProfile(profiles []*cover.Profile, p *cover.Profile) []*cover.Profile {
+	i := sort.Search(len(profiles), func(i int) bool { return profiles[i].FileName >= p.FileName })
+	if i < len(profiles) && profiles[i].FileName == p.FileName {
+		MergeCoverProfiles(profiles[i], p)
+	} else {
+		profiles = append(profiles, nil)
+		copy(profiles[i+1:], profiles[i:])
+		profiles[i] = p
+	}
+	return profiles
+}
+
+func DumpCoverProfiles(profiles []*cover.Profile, out io.Writer) error {
+	if len(profiles) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(out, "mode: %s\n", profiles[0].Mode); err != nil {
+		return err
+	}
+	for _, p := range profiles {
+		for _, b := range p.Blocks {
+			if _, err := fmt.Fprintf(out, "%s:%d.%d,%d.%d %d %d\n", p.FileName, b.StartLine, b.StartCol, b.EndLine, b.EndCol, b.NumStmt, b.Count); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func MergeCoverProfiles(into *cover.Profile, merge *cover.Profile) error {
+	if into.Mode != merge.Mode {
+		return fmt.Errorf("cannot merge profiles with different modes")
+	}
+	// Since the blocks are sorted, we can keep track of where the last block
+	// was inserted and only look at the blocks after that as targets for merge
+	startIndex := 0
+	for _, b := range merge.Blocks {
+		var err error
+		startIndex, err = mergeProfileBlock(into, b, startIndex)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeProfileBlock(p *cover.Profile, pb cover.ProfileBlock, startIndex int) (int, error) {
+	sortFunc := func(i int) bool {
+		pi := p.Blocks[i+startIndex]
+		return pi.StartLine >= pb.StartLine && (pi.StartLine != pb.StartLine || pi.StartCol >= pb.StartCol)
+	}
+
+	i := 0
+	if sortFunc(i) != true {
+		i = sort.Search(len(p.Blocks)-startIndex, sortFunc)
+	}
+
+	i += startIndex
+	if i < len(p.Blocks) && p.Blocks[i].StartLine == pb.StartLine && p.Blocks[i].StartCol == pb.StartCol {
+		if p.Blocks[i].EndLine != pb.EndLine || p.Blocks[i].EndCol != pb.EndCol {
+			return i, fmt.Errorf("gocovmerge: overlapping merge %v %v %v", p.FileName, p.Blocks[i], pb)
+		}
+		switch p.Mode {
+		case "set":
+			p.Blocks[i].Count |= pb.Count
+		case "count", "atomic":
+			p.Blocks[i].Count += pb.Count
+		default:
+			return i, fmt.Errorf("gocovmerge: unsupported covermode '%s'", p.Mode)
+		}
+
+	} else {
+		if i > 0 {
+			pa := p.Blocks[i-1]
+			if pa.EndLine >= pb.EndLine && (pa.EndLine != pb.EndLine || pa.EndCol > pb.EndCol) {
+				return i, fmt.Errorf("gocovmerge: overlap before %v %v %v", p.FileName, pa, pb)
+			}
+		}
+		if i < len(p.Blocks)-1 {
+			pa := p.Blocks[i+1]
+			if pa.StartLine <= pb.StartLine && (pa.StartLine != pb.StartLine || pa.StartCol < pb.StartCol) {
+				return i, fmt.Errorf("gocovmerge: overlap after %v %v %v", p.FileName, pa, pb)
+			}
+		}
+		p.Blocks = append(p.Blocks, cover.ProfileBlock{})
+		copy(p.Blocks[i+1:], p.Blocks[i:])
+		p.Blocks[i] = pb
+	}
+
+	return i + 1, nil
+}

--- a/ginkgo/internal/profiles_and_reports.go
+++ b/ginkgo/internal/profiles_and_reports.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +11,7 @@ import (
 	"github.com/google/pprof/profile"
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/ginkgo/v2/types"
+	"golang.org/x/tools/cover"
 )
 
 func AbsPathForGeneratedAsset(assetName string, suite TestSuite, cliConfig types.CLIConfig, process int) string {
@@ -144,38 +144,26 @@ func FinalizeProfilesAndReportsForSuites(suites TestSuites, cliConfig types.CLIC
 	return messages, nil
 }
 
-// loads each profile, combines them, deletes them, stores them in destination
+// loads each profile, merges them, deletes them, stores them in destination
 func MergeAndCleanupCoverProfiles(profiles []string, destination string) error {
-	combined := &bytes.Buffer{}
-	modeRegex := regexp.MustCompile(`^mode: .*\n`)
-	for i, profile := range profiles {
-		contents, err := os.ReadFile(profile)
+	var merged []*cover.Profile
+	for _, file := range profiles {
+		parsedProfiles, err := cover.ParseProfiles(file)
 		if err != nil {
-			return fmt.Errorf("Unable to read coverage file %s:\n%s", profile, err.Error())
+			return err
 		}
-		os.Remove(profile)
-
-		// remove the cover mode line from every file
-		// except the first one
-		if i > 0 {
-			contents = modeRegex.ReplaceAll(contents, []byte{})
-		}
-
-		_, err = combined.Write(contents)
-
-		// Add a newline to the end of every file if missing.
-		if err == nil && len(contents) > 0 && contents[len(contents)-1] != '\n' {
-			_, err = combined.Write([]byte("\n"))
-		}
-
-		if err != nil {
-			return fmt.Errorf("Unable to append to coverprofile:\n%s", err.Error())
+		os.Remove(file)
+		for _, p := range parsedProfiles {
+			merged = AddCoverProfile(merged, p)
 		}
 	}
-
-	err := os.WriteFile(destination, combined.Bytes(), 0666)
+	dst, err := os.OpenFile(destination, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
-		return fmt.Errorf("Unable to create combined cover profile:\n%s", err.Error())
+		return err
+	}
+	err = DumpCoverProfiles(merged, dst)
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
I copy [gocovmerge](https://github.com/shabbyrobe/gocovmerge) to ginkgo, because it hasn't versions, and the code is easy to maintain.