### PR TITLE
docs/index.md: Typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1221,13 +1221,13 @@ It("panics in a goroutine", func() {
 
 ```go
 It("panics in a goroutine", func() {
-  done := make(chan struct{})
+  c := make(chan struct{})
   go func() {
     defer GinkgoRecover()
     Fail("boom")
     close(c)
   }()
-  Eventually(done).Should(BeClosed())
+  Eventually(c).Should(BeClosed())
 })
 ```
 


### PR DESCRIPTION
Since it's just a minor nit I don't see any point in opening an issue.

Code was incorrect, this commit fixes that.

Also change the name of the chan variable to be the same as in the invalid case above it.