### PR TITLE
add `--github-output` for nicer output in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
         go-version: ${{ matrix.version }}
     - uses: actions/checkout@v4
     - run: go vet ./...
-    - run: go run ./ginkgo -r -randomize-all -randomize-suites -race -trace -procs=2 -poll-progress-after=10s -poll-progress-interval=10s
+    - run: go run ./ginkgo --github-output -r -randomize-all -randomize-suites -race -trace -procs=2 -poll-progress-after=10s -poll-progress-interval=10s

--- a/docs/index.md
+++ b/docs/index.md
@@ -3382,6 +3382,7 @@ When you [filter specs](#filtering-specs) using Ginkgo's various filtering mecha
 Here are a grab bag of other settings:
 
 You can disable Ginkgo's color output by running `ginkgo --no-color`.
+You can also output in a format that makes it easier to read in github actions console by running `ginkgo --github-output`.
 
 By default, Ginkgo only emits full stack traces when a spec panics.  When a normal assertion failure occurs, Ginkgo simply emits the line at which the failure occurred.  You can, instead, have Ginkgo always emit the full stack trace by running `ginkgo --trace`.
 
@@ -3705,6 +3706,8 @@ Here's why:
 - `--json-report=report.json` will generate a JSON formatted report file.  You can store these off and use them later to get structured access to the suite and spec results.  Alternatively (or in addition) you can use `--junit-report=report.xml` to generate JUnit-formatted reports; these are compatible with several existing CI systems.
 - `--timeout` allows you to specify a timeout for the `ginkgo` run.  The default duration is one hour, which may or may not be enough!
 - `--poll-progress-after` and `--poll-progress-interval` will allow you to learn where long-running specs are getting stuck.  Choose a values for `X` and `Y` that are appropriate to your suite.  A long-running integration suite, for example, might set `X` to `120s` and `Y` to `30s` - whereas a quicker set of unit tests might not need this setting.  Note that if you precompile suites and run them from a different directory relative to your source code, you may also need to set `--source-root` to enable Ginkgo to emit source code lines when generating progress reports.
+
+If running on Github actions: `--github-output` will make the output more readable in the Github actions console.
 
 ### Supporting Custom Suite Configuration
 

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -187,13 +187,13 @@ func (r *DefaultReporter) wrapTextBlock(sectionName string, fn func()) {
 	if r.conf.GithubOutput {
 		r.emitBlock(r.fi(1, "::group::%s", sectionName))
 	} else {
-		r.emitBlock(r.fi(1, "{{gray}}<< %s{{/}}", sectionName))
+		r.emitBlock(r.fi(1, "{{gray}}%s >>{{/}}", sectionName))
 	}
 	fn()
 	if r.conf.GithubOutput {
 		r.emitBlock(r.fi(1, "::endgroup::"))
 	} else {
-		r.emitBlock(r.fi(1, "{{gray}}%s >>{{/}}", sectionName))
+		r.emitBlock(r.fi(1, "{{gray}}<< %s{{/}}", sectionName))
 	}
 
 }

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -182,6 +182,22 @@ func (r *DefaultReporter) WillRun(report types.SpecReport) {
 	r.emitBlock(r.f(r.codeLocationBlock(report, "{{/}}", v.Is(types.VerbosityLevelVeryVerbose), false)))
 }
 
+func (r *DefaultReporter) wrapTextBlock(sectionName string, fn func()) {
+	r.emitBlock("\n")
+	if r.conf.GithubOutput {
+		r.emitBlock(r.fi(1, "::group::%s", sectionName))
+	} else {
+		r.emitBlock(r.fi(1, "{{gray}}<< %s{{/}}", sectionName))
+	}
+	fn()
+	if r.conf.GithubOutput {
+		r.emitBlock(r.fi(1, "::endgroup::"))
+	} else {
+		r.emitBlock(r.fi(1, "{{gray}}%s >>{{/}}", sectionName))
+	}
+
+}
+
 func (r *DefaultReporter) DidRun(report types.SpecReport) {
 	v := r.conf.Verbosity()
 	inParallel := report.RunningInParallel
@@ -283,26 +299,23 @@ func (r *DefaultReporter) DidRun(report types.SpecReport) {
 
 	//Emit Stdout/Stderr Output
 	if showSeparateStdSection {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(1, "{{gray}}Captured StdOut/StdErr Output >>{{/}}"))
-		r.emitBlock(r.fi(1, "%s", report.CapturedStdOutErr))
-		r.emitBlock(r.fi(1, "{{gray}}<< Captured StdOut/StdErr Output{{/}}"))
+		r.wrapTextBlock("Captured StdOut/StdErr Output", func() {
+			r.emitBlock(r.fi(1, "%s", report.CapturedStdOutErr))
+		})
 	}
 
 	if showSeparateVisibilityAlwaysReportsSection {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(1, "{{gray}}Report Entries >>{{/}}"))
-		for _, entry := range report.ReportEntries.WithVisibility(types.ReportEntryVisibilityAlways) {
-			r.emitReportEntry(1, entry)
-		}
-		r.emitBlock(r.fi(1, "{{gray}}<< Report Entries{{/}}"))
+		r.wrapTextBlock("Report Entries", func() {
+			for _, entry := range report.ReportEntries.WithVisibility(types.ReportEntryVisibilityAlways) {
+				r.emitReportEntry(1, entry)
+			}
+		})
 	}
 
 	if showTimeline {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(1, "{{gray}}Timeline >>{{/}}"))
-		r.emitTimeline(1, report, timeline)
-		r.emitBlock(r.fi(1, "{{gray}}<< Timeline{{/}}"))
+		r.wrapTextBlock("Timeline", func() {
+			r.emitTimeline(1, report, timeline)
+		})
 	}
 
 	// Emit Failure Message
@@ -405,7 +418,11 @@ func (r *DefaultReporter) emitShortFailure(indent uint, state types.SpecState, f
 func (r *DefaultReporter) emitFailure(indent uint, state types.SpecState, failure types.Failure, includeAdditionalFailure bool) {
 	highlightColor := r.highlightColorForState(state)
 	r.emitBlock(r.fi(indent, highlightColor+"[%s] %s{{/}}", r.humanReadableState(state), failure.Message))
-	r.emitBlock(r.fi(indent, highlightColor+"In {{bold}}[%s]{{/}}"+highlightColor+" at: {{bold}}%s{{/}} {{gray}}@ %s{{/}}\n", failure.FailureNodeType, failure.Location, failure.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	if r.conf.GithubOutput {
+		r.emitBlock(r.fi(indent, "::error file=%s,line=%d::%s %s", failure.Location.FileName, failure.Location.LineNumber, failure.FailureNodeType, failure.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	} else {
+		r.emitBlock(r.fi(indent, highlightColor+"In {{bold}}[%s]{{/}}"+highlightColor+" at: {{bold}}%s{{/}} {{gray}}@ %s{{/}}\n", failure.FailureNodeType, failure.Location, failure.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	}
 	if failure.ForwardedPanic != "" {
 		r.emitBlock("\n")
 		r.emitBlock(r.fi(indent, highlightColor+"%s{{/}}", failure.ForwardedPanic))

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -176,6 +176,7 @@ const (
 	VeryVerbose
 	FullTrace
 	ShowNodeEvents
+	GithubOutput
 
 	Parallel //used in the WillRun => DidRun specs to capture behavior when running in parallel
 )
@@ -204,6 +205,9 @@ func (cf ConfigFlag) String() string {
 	if cf.Has(Parallel) {
 		out = append(out, "parallel")
 	}
+	if cf.Has(GithubOutput) {
+		out = append(out, "github-output")
+	}
 	return strings.Join(out, "|")
 }
 
@@ -226,6 +230,7 @@ func C(flags ...ConfigFlag) types.ReporterConfig {
 		VeryVerbose:    f.Has(VeryVerbose),
 		FullTrace:      f.Has(FullTrace),
 		ShowNodeEvents: f.Has(ShowNodeEvents),
+		GithubOutput:   f.Has(GithubOutput),
 	}
 }
 
@@ -768,6 +773,18 @@ var _ = Describe("DefaultReporter", func() {
 				"  hello there",
 				"  this is my output",
 				"  {{gray}}<< Captured StdOut/StdErr Output{{/}}",
+				DELIMITER,
+				""),
+			Case(Parallel|GithubOutput,
+				DELIMITER,
+				spr("{{green}}%s [1.000 seconds]{{/}}", DENOTER),
+				"{{green}}{{bold}}A{{/}}",
+				"{{gray}}cl0.go:12{{/}}",
+				"",
+				"  ::group::Captured StdOut/StdErr Output",
+				"  hello there",
+				"  this is my output",
+				"  ::endgroup::",
 				DELIMITER,
 				""),
 		),

--- a/types/config.go
+++ b/types/config.go
@@ -89,6 +89,7 @@ type ReporterConfig struct {
 	VeryVerbose    bool
 	FullTrace      bool
 	ShowNodeEvents bool
+	GithubOutput   bool
 
 	JSONReport     string
 	JUnitReport    string
@@ -331,6 +332,8 @@ var ReporterConfigFlags = GinkgoFlags{
 		Usage: "If set, default reporter prints out the full stack trace when a failure occurs"},
 	{KeyPath: "R.ShowNodeEvents", Name: "show-node-events", SectionKey: "output",
 		Usage: "If set, default reporter prints node > Enter and < Exit events when specs fail"},
+	{KeyPath: "R.GithubOutput", Name: "github-output", SectionKey: "output",
+		Usage: "If set, default reporter prints easier to manage output in Github Actions."},
 
 	{KeyPath: "R.JSONReport", Name: "json-report", UsageArgument: "filename.json", SectionKey: "output",
 		Usage: "If set, Ginkgo will generate a JSON-formatted test report at the specified location."},


### PR DESCRIPTION
Leverage github's special formats to output nicer output

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions

Fix #1372