### PR TITLE
fix: lock suite.currentSpecReport.SpecEvents

### DIFF
--- a/internal/suite.go
+++ b/internal/suite.go
@@ -415,7 +415,10 @@ func (suite *Suite) processCurrentSpecReport() {
 	if suite.isRunningInParallel() {
 		suite.client.PostDidRun(suite.currentSpecReport)
 	}
+
+	suite.selectiveLock.Lock()
 	suite.report.SpecReports = append(suite.report.SpecReports, suite.currentSpecReport)
+	suite.selectiveLock.Unlock()
 
 	if suite.currentSpecReport.State.Is(types.SpecStateFailureStates) {
 		suite.report.SuiteSucceeded = false


### PR DESCRIPTION
I'm not sure this is the right fix, but found a race condition when using By() concurrently. 


```
WARNING: DATA RACE 12:52
Read at 0x00c000713248 by goroutine 51: 12:52
  github.com/onsi/ginkgo/v2/internal.(*Suite).processCurrentSpecReport() 
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/internal/suite.go:414 +0x7a 
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/internal/group.go:374 +0xd97
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs() 
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/internal/suite.go:489 +0x1291
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run() 
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/internal/suite.go:130 +0x5f7 
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/core_dsl.go:300 +0xeaa
Previous write at 0x00c000713248 by goroutine 14849: 
  github.com/onsi/ginkgo/v2/internal.(*Suite).handleSpecEvent() 
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/internal/suite.go:284 +0x204
  github.com/onsi/ginkgo/v2/internal.(*Suite).By()
      /home/semaphore/git/go/1.21.7/pkg/mod/github.com/onsi/ginkgo/v2@v2.15.0/internal/suite.go:307 +0x1d7 
  github.com/onsi/ginkgo/v2.By()
```
