### PR TITLE
ignore hidden files

### DIFF
--- a/ginkgo/watch/package_hash.go
+++ b/ginkgo/watch/package_hash.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -79,6 +80,10 @@ func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Ti
 			continue
 		}
 
+		if isHiddenFile(info) {
+			continue
+		}
+
 		if goTestRegExp.MatchString(info.Name()) {
 			testHash += p.hashForFileInfo(info)
 			if info.ModTime().After(testModifiedTime) {
@@ -101,6 +106,10 @@ func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Ti
 	}
 
 	return
+}
+
+func isHiddenFile(info os.FileInfo) bool {
+	return strings.HasPrefix(info.Name(), ".") || strings.HasPrefix(info.Name(), "_")
 }
 
 func (p *PackageHash) hashForFileInfo(info os.FileInfo) string {


### PR DESCRIPTION
Hidden files are defined here as those beginning with '.' or '_'.

This is a departure from previous behavior, where hidden source and test files were evaluated via watch. Evaluating hidden files is undesirable because some editors create hidden temporary files, and these files shouldn't trigger test runs.

No flag is added to restore the original behavior at this time as the new behavior is the same as "go test", and it is not expected that it will cause problems. If this change affects you, consider opening a PR to add a CLI flag to restore the previous behavior.

https://github.com/onsi/ginkgo/issues/1401