### PR TITLE
add AddSpecialSuiteFailureReasons to reduce boilerplate

### DIFF
--- a/ginkgo/internal/profiles_and_reports.go
+++ b/ginkgo/internal/profiles_and_reports.go
@@ -107,13 +107,13 @@ func FinalizeProfilesAndReportsForSuites(suites TestSuites, cliConfig types.CLIC
 		}
 		switch suite.State {
 		case TestSuiteStateFailedToCompile:
-			report.SpecialSuiteFailureReasons = append(report.SpecialSuiteFailureReasons, suite.CompilationError.Error())
+			report.AddSpecialSuiteFailureReasons(suite.CompilationError.Error())
 		case TestSuiteStateFailedDueToTimeout:
-			report.SpecialSuiteFailureReasons = append(report.SpecialSuiteFailureReasons, TIMEOUT_ELAPSED_FAILURE_REASON)
+			report.AddSpecialSuiteFailureReasons(TIMEOUT_ELAPSED_FAILURE_REASON)
 		case TestSuiteStateSkippedDueToPriorFailures:
-			report.SpecialSuiteFailureReasons = append(report.SpecialSuiteFailureReasons, PRIOR_FAILURES_FAILURE_REASON)
+			report.AddSpecialSuiteFailureReasons(PRIOR_FAILURES_FAILURE_REASON)
 		case TestSuiteStateSkippedDueToEmptyCompilation:
-			report.SpecialSuiteFailureReasons = append(report.SpecialSuiteFailureReasons, EMPTY_SKIP_FAILURE_REASON)
+			report.AddSpecialSuiteFailureReasons(EMPTY_SKIP_FAILURE_REASON)
 			report.SuiteSucceeded = true
 		}
 

--- a/internal/suite.go
+++ b/internal/suite.go
@@ -468,7 +468,7 @@ func (suite *Suite) runSpecs(description string, suiteLabels Labels, suitePath s
 		for {
 			groupedSpecIdx, err := nextIndex()
 			if err != nil {
-				suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, fmt.Sprintf("Failed to iterate over specs:\n%s", err.Error()))
+				suite.report.AddSpecialSuiteFailureReasons(fmt.Sprintf("Failed to iterate over specs:\n%s", err.Error()))
 				suite.report.SuiteSucceeded = false
 				break
 			}
@@ -490,12 +490,12 @@ func (suite *Suite) runSpecs(description string, suiteLabels Labels, suitePath s
 		}
 
 		if suite.config.FailOnPending && specs.HasAnySpecsMarkedPending() {
-			suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, "Detected pending specs and --fail-on-pending is set")
+			suite.report.AddSpecialSuiteFailureReasons("Detected pending specs and --fail-on-pending is set")
 			suite.report.SuiteSucceeded = false
 		}
 
 		if suite.config.FailOnEmpty && specs.CountWithoutSkip() == 0 {
-			suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, "Detected no specs ran and --fail-on-empty is set")
+			suite.report.AddSpecialSuiteFailureReasons("Detected no specs ran and --fail-on-empty is set")
 			suite.report.SuiteSucceeded = false
 		}
 	}
@@ -506,13 +506,13 @@ func (suite *Suite) runSpecs(description string, suiteLabels Labels, suitePath s
 
 	interruptStatus := suite.interruptHandler.Status()
 	if interruptStatus.Interrupted() {
-		suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, interruptStatus.Cause.String())
+		suite.report.AddSpecialSuiteFailureReasons(interruptStatus.Cause.String())
 		suite.report.SuiteSucceeded = false
 	}
 	suite.report.EndTime = time.Now()
 	suite.report.RunTime = suite.report.EndTime.Sub(suite.report.StartTime)
 	if !suite.deadline.IsZero() && suite.report.EndTime.After(suite.deadline) {
-		suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, "Suite Timeout Elapsed")
+		suite.report.AddSpecialSuiteFailureReasons("Suite Timeout Elapsed")
 		suite.report.SuiteSucceeded = false
 	}
 
@@ -540,7 +540,7 @@ func (suite *Suite) runBeforeSuite(numSpecsThatWillBeRun int) {
 		suite.reporter.WillRun(suite.currentSpecReport)
 		suite.runSuiteNode(beforeSuiteNode)
 		if suite.currentSpecReport.State.Is(types.SpecStateSkipped) {
-			suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, "Suite skipped in BeforeSuite")
+			suite.report.AddSpecialSuiteFailureReasons("Suite skipped in BeforeSuite")
 			suite.skipAll = true
 		}
 		suite.processCurrentSpecReport()


### PR DESCRIPTION
basically
```
report.SpecialSuiteFailureReasons = append(report.SpecialSuiteFailureReasons, suite.CompilationError.Error())
->
report.AddSpecialSuiteFailureReasons(suite.CompilationError.Error())
```
because the boilerplate was a bit annoying to see everywhere and now the lines are easier to read