### PR TITLE
Allow disabling color with flag GINGKO_COLOR

### DIFF
--- a/core_dsl.go
+++ b/core_dsl.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -257,6 +258,14 @@ func RunSpecs(t GinkgoTestingT, description string, args ...interface{}) bool {
 	suiteLabels := extractSuiteConfiguration(args)
 
 	var reporter reporters.Reporter
+	reporterConfig := reporterConfig
+	if value, present := os.LookupEnv("GINGKO_COLOR"); present {
+		b, err := strconv.ParseBool(value)
+		if err == nil {
+			reporterConfig.NoColor = !b
+		}
+	}
+
 	if suiteConfig.ParallelTotal == 1 {
 		reporter = reporters.NewDefaultReporter(reporterConfig, formatter.ColorableStdOut)
 		outputInterceptor = internal.NoopOutputInterceptor{}

--- a/types/config.go
+++ b/types/config.go
@@ -115,7 +115,16 @@ func (rc ReporterConfig) WillGenerateReport() bool {
 }
 
 func NewDefaultReporterConfig() ReporterConfig {
-	return ReporterConfig{}
+	c := ReporterConfig{}
+
+	if value, present := os.LookupEnv("GINGKO_COLOR"); present {
+		b, err := strconv.ParseBool(value)
+		if err == nil {
+			c.NoColor = !b
+		}
+	}
+
+	return c
 }
 
 // Configuration for the Ginkgo CLI


### PR DESCRIPTION
When integrating golang packages using ginkgo, such as CI/CD systems or Linux distributions, there are situations where the test output is tracked in text files and presented without ANSI color decoding.  For those situations, in particular when the tests are invoked directly by `go test`,  and thus without the `gingko` CLI driver, controller color output via an environment variable can be much more convenient