### PR TITLE
Add label to serial nodes

### DIFF
--- a/integration/timeline_test.go
+++ b/integration/timeline_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Timeline output", func() {
 
 			Ω(session).Should(gbytes.Say(`3 specs`))
 
-			Ω(session).Should(gbytes.Say(`a full timeline\n`))
+			Ω(session).Should(gbytes.Say(`a full timeline \[Serial\]\n`))
 			Ω(session).Should(gbytes.Say(`a flaky test\n`))
 			Ω(session).Should(gbytes.Say(`retries a few times\n`))
 			Ω(session).Should(gbytes.Say(`> Enter \[BeforeEach\] a flaky test`))
@@ -270,7 +270,7 @@ var _ = Describe("Timeline output", func() {
 			Ω(session).Should(gbytes.Say(`3 specs`))
 
 			Ω(session).Should(gbytes.Say(retryDenoter + ` \[FLAKEY TEST - TOOK 3 ATTEMPTS TO PASS\]`))
-			Ω(session).Should(gbytes.Say(`a full timeline\n`))
+			Ω(session).Should(gbytes.Say(`a full timeline \[Serial\]\n`))
 			Ω(session).Should(gbytes.Say(`a flaky test\n`))
 			Ω(session).Should(gbytes.Say(`retries a few times\n`))
 			Ω(session).Should(gbytes.Say(`> Enter \[BeforeEach\] a flaky test`))

--- a/internal/node.go
+++ b/internal/node.go
@@ -241,6 +241,9 @@ func NewNode(deprecationTracker *types.DeprecationTracker, nodeType types.NodeTy
 			}
 		case t == reflect.TypeOf(Serial):
 			node.MarkedSerial = bool(arg.(serialType))
+			if !labelsSeen["Serial"] {
+				node.Labels = append(node.Labels, "Serial")
+			}
 			if !nodeType.Is(types.NodeTypesForContainerAndIt) {
 				appendError(types.GinkgoErrors.InvalidDecoratorForNodeType(node.CodeLocation, nodeType, "Serial"))
 			}

--- a/internal/node_test.go
+++ b/internal/node_test.go
@@ -269,6 +269,7 @@ var _ = Describe("Constructing nodes", func() {
 		It("marks the node as Serial", func() {
 			node, errors := internal.NewNode(dt, ntIt, "text", body, Serial)
 			Ω(node.MarkedSerial).Should(BeTrue())
+			Ω(node.Labels).Should(Equal(Labels{"Serial"}))
 			ExpectAllWell(errors)
 		})
 		It("allows containers to be marked", func() {


### PR DESCRIPTION
Adding a label in order to be able to filter tests decorated with `Serial`.

Fixes #1483 