### PR TITLE
docs: fix test workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Ginkgo](https://onsi.github.io/ginkgo/images/ginkgo.png)
 
-[![test](https://github.com/onsi/ginkgo/workflows/test/badge.svg?branch=master)](https://github.com/onsi/ginkgo/actions?query=workflow%3Atest+branch%3Amaster) | [Ginkgo Docs](https://onsi.github.io/ginkgo/)
+[![test](https://github.com/onsi/ginkgo/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/onsi/ginkgo/actions?query=workflow%3Atest+branch%3Amaster) | [Ginkgo Docs](https://onsi.github.io/ginkgo/)
 
 ---
 


### PR DESCRIPTION
It looks like the path to the test workflow badge is not correct, causing the badge to not render correctly. 

It currently shows `no status` instead of `passing`.

This change alters the path to point directly to the workflow run on the master branch.