### PR TITLE
Fix typo in documentation: DescribeHandleSubtree -> DescribeTableSubtree

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1724,7 +1724,7 @@ Describe("handling requests", func() {
 })
 ```
 
-all the infrastructure around generating table entry descriptions applies here as well - though the description will be the title of the generated container.  Note that you **must** add subject nodes in the body function if you want `DescribeHandleSubtree` to add specs.
+all the infrastructure around generating table entry descriptions applies here as well - though the description will be the title of the generated container.  Note that you **must** add subject nodes in the body function if you want `DescribeTableSubtree` to add specs.
 
 ### Alternatives to Dot-Importing Ginkgo
 


### PR DESCRIPTION
There is a mention of `DescribeHandleSubtree`, but this name doesn't appear anywhere else in the docs or in the code files. From reading the text around it, I think it should be `DescribeTableSubtree` instead.

Sorry if I misunderstood!