### PR TITLE
Bug Fix: Add GinkoTBWrapper.Chdir() and GinkoTBWrapper.Context()

### DIFF
--- a/ginkgo_t_dsl.go
+++ b/ginkgo_t_dsl.go
@@ -130,6 +130,12 @@ type GinkgoTBWrapper struct {
 func (g *GinkgoTBWrapper) Cleanup(f func()) {
 	g.GinkgoT.Cleanup(f)
 }
+func (g *GinkgoTBWrapper) Chdir(dir string) {
+	g.GinkgoT.Chdir(dir)
+}
+func (g *GinkgoTBWrapper) Context() context.Context {
+	return g.GinkgoT.Context()
+}
 func (g *GinkgoTBWrapper) Error(args ...any) {
 	g.GinkgoT.Error(args...)
 }


### PR DESCRIPTION
Add `Chdir()` and `Context()` to `GinkgoTBWrapper`. `GinkoTB().Context()` is currently causing `runtime error: invalid memory address or nil pointer dereference`

Related:
- https://github.com/onsi/ginkgo/commit/37a511b5bca15e628309b421c20e834b7f67dad4
- https://github.com/onsi/ginkgo/issues/1519