### PR TITLE
chore: fix some CodeQL warnings

### DIFF
--- a/ginkgo/watch/dependencies.go
+++ b/ginkgo/watch/dependencies.go
@@ -2,11 +2,8 @@ package watch
 
 import (
 	"go/build"
-	"regexp"
+	"strings"
 )
-
-var ginkgoAndGomegaFilter = regexp.MustCompile(`github\.com/onsi/ginkgo|github\.com/onsi/gomega`)
-var ginkgoIntegrationTestFilter = regexp.MustCompile(`github\.com/onsi/ginkgo/integration`) //allow us to integration test this thing
 
 type Dependencies struct {
 	deps map[string]int
@@ -78,7 +75,7 @@ func (d Dependencies) resolveAndAdd(deps []string, depth int) {
 		if err != nil {
 			continue
 		}
-		if !pkg.Goroot && (!ginkgoAndGomegaFilter.MatchString(pkg.Dir) || ginkgoIntegrationTestFilter.MatchString(pkg.Dir)) {
+		if !pkg.Goroot && (!matchesGinkgoOrGomega(pkg.Dir) || matchesGinkgoIntegration(pkg.Dir)) {
 			d.addDepIfNotPresent(pkg.Dir, depth)
 		}
 	}
@@ -89,4 +86,12 @@ func (d Dependencies) addDepIfNotPresent(dep string, depth int) {
 	if !ok {
 		d.deps[dep] = depth
 	}
+}
+
+func matchesGinkgoOrGomega(s string) bool {
+	return strings.Contains(s, "github.com/onsi/ginkgo") || strings.Contains(s, "github.com/onsi/gomega")
+}
+
+func matchesGinkgoIntegration(s string) bool {
+	return strings.Contains(s, "github.com/onsi/ginkgo/integration") // allow us to integration test this thing
 }

--- a/internal/progress_report.go
+++ b/internal/progress_report.go
@@ -236,7 +236,7 @@ func extractRunningGoroutines() ([]types.Goroutine, error) {
 		}
 		functionCall.Filename = line[:delimiterIdx]
 		line = strings.Split(line[delimiterIdx+1:], " ")[0]
-		lineNumber, err := strconv.ParseInt(line, 10, 64)
+		lineNumber, err := strconv.ParseInt(line, 10, 32)
 		functionCall.Line = int(lineNumber)
 		if err != nil {
 			return nil, types.GinkgoErrors.FailedToParseStackTrace(fmt.Sprintf("Invalid function call line number: %s\n%s", line, err.Error()))


### PR DESCRIPTION
CodeQL has flagged some warnings:
1) an integer conversion issue in progress_report.go
2) regexp without anchor in dependencies.go

(1) should be fixed by changing the call to ParseInt(), and (2) can be implemented more simply by using substring matching, which will likely make the warning go away.