### PR TITLE
fix(types): ignore nameless nodes on FullText()

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -287,6 +288,9 @@ func (report SpecReport) FullText() string {
 	if report.LeafNodeText != "" {
 		texts = append(texts, report.LeafNodeText)
 	}
+	texts = slices.DeleteFunc(texts, func(t string) bool {
+		return t == ""
+	})
 	return strings.Join(texts, " ")
 }
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -244,8 +244,10 @@ var _ = Describe("Types", func() {
 			Ω(types.SpecReport{State: types.SpecStateInterrupted}.Failed()).Should(BeTrue())
 		})
 
-		It("can return a concatenated set of texts", func() {
-			Ω(CurrentSpecReport().FullText()).Should(Equal("Types SpecReport Helper Functions can return a concatenated set of texts"))
+		Describe("", func() {
+			It("can return a concatenated set of texts", func() {
+				Ω(CurrentSpecReport().FullText()).Should(Equal("Types SpecReport Helper Functions can return a concatenated set of texts"))
+			})
 		})
 
 		It("can return the name of the file it's spec is in", func() {


### PR DESCRIPTION
We stumbled upon an issue where `.FullText()` was returning a leading space in the Spec name due to an empty `Describe`.

Not entirely sure if this behavior is intentional or not, but in any case, the pull request is ready if you’d like to take a look and consider accepting it 🙂
