### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/ginkgo/internal/test_suite.go
+++ b/ginkgo/internal/test_suite.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2/types"
@@ -39,13 +40,7 @@ const (
 var TestSuiteStateFailureStates = []TestSuiteState{TestSuiteStateFailed, TestSuiteStateFailedDueToTimeout, TestSuiteStateFailedToCompile}
 
 func (state TestSuiteState) Is(states ...TestSuiteState) bool {
-	for _, suiteState := range states {
-		if suiteState == state {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(states, state)
 }
 
 type TestSuite struct {

--- a/ginkgo/performance/performance_suite_test.go
+++ b/ginkgo/performance/performance_suite_test.go
@@ -223,7 +223,7 @@ func SampleScenarios(cache gmeasure.ExperimentCache, numSamples int, cacheVersio
 		}
 		experiments[name] = gmeasure.NewExperiment(name)
 		AddReportEntry(name, experiments[name], Offset(1), ReportEntryVisibilityFailureOrVerbose)
-		for i := 0; i < numSamples; i++ {
+		for range numSamples {
 			runs = append(runs, scenario)
 		}
 	}

--- a/ginkgo/unfocus/unfocus_command.go
+++ b/ginkgo/unfocus/unfocus_command.go
@@ -40,7 +40,7 @@ func unfocusSpecs() {
 	wg := sync.WaitGroup{}
 	wg.Add(workers)
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go func() {
 			for path := range goFiles {
 				unfocusFile(path)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -433,7 +433,7 @@ var _ = Describe("Running Specs", func() {
 			report := Reports(fm.LoadJSONReports("large", "report.json")[0].SpecReports)
 
 			expectedNames := []string{}
-			for i := 0; i < 2048; i++ {
+			for i := range 2048 {
 				expectedNames = append(expectedNames, fmt.Sprintf("%d", i))
 			}
 

--- a/integration/timeline_test.go
+++ b/integration/timeline_test.go
@@ -30,7 +30,6 @@ var _ = Describe("Timeline output", func() {
 			{"--no-color", "--seed=17", "--nodes=2", "--succinct"},
 		}
 		for _, args := range argGroups {
-			args := args
 			It(fmt.Sprintf("should emit a timeline (%s)", strings.Join(args, " ")), func() {
 				session := startGinkgo(fm.PathTo("timeline"), args...)
 				Eventually(session).Should(gexec.Exit(1))

--- a/internal/group.go
+++ b/internal/group.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/onsi/ginkgo/v2/types"
@@ -62,12 +63,7 @@ func (pairs runOncePairs) runOncePairFor(nodeID uint) runOncePair {
 }
 
 func (pairs runOncePairs) hasRunOncePair(pair runOncePair) bool {
-	for i := range pairs {
-		if pairs[i] == pair {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(pairs, pair)
 }
 
 func (pairs runOncePairs) withType(nodeTypes types.NodeType) runOncePairs {

--- a/internal/internal_integration/cleanup_test.go
+++ b/internal/internal_integration/cleanup_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Cleanup", func() {
 						It("A", func() {
 							wg := &sync.WaitGroup{}
 							wg.Add(5)
-							for i := 0; i < 5; i++ {
+							for i := range 5 {
 								i := i
 								go func() {
 									DeferCleanup(rt.Run, fmt.Sprintf("dc-%d", i))

--- a/internal/internal_integration/report_entries_test.go
+++ b/internal/internal_integration/report_entries_test.go
@@ -73,7 +73,7 @@ var _ = Describe("ReportEntries", func() {
 				})
 
 				It("reporter", func() {
-					for i := 0; i < 5; i++ {
+					for i := range 5 {
 						time.Sleep(20 * time.Millisecond)
 						AddReportEntry(fmt.Sprintf("waiting... %d", i))
 						Ω(len(CurrentSpecReport().ReportEntries)).Should(BeNumerically("<", (i+1)*10))

--- a/internal/node_test.go
+++ b/internal/node_test.go
@@ -1768,7 +1768,7 @@ var _ = Describe("Iteration Performance", Serial, Label("performance"), func() {
 
 		size := 1000
 		nodes := make(Nodes, size)
-		for i := 0; i < size; i++ {
+		for i := range size {
 			nodes[i] = N(ntAf)
 		}
 		nodes[size-1] = N(ntIt)
@@ -1793,7 +1793,7 @@ var _ = Describe("Iteration Performance", Serial, Label("performance"), func() {
 
 		experiment.SampleDuration("counter", func(idx int) {
 			numIts := 0
-			for i := 0; i < len(nodes); i++ {
+			for i := range nodes {
 				if nodes[i].NodeType.Is(ntIt) {
 					numIts += 1
 				}
@@ -1809,7 +1809,7 @@ var _ = Describe("Iteration Performance", Serial, Label("performance"), func() {
 
 		size := 1000
 		nodes := make(Nodes, size)
-		for i := 0; i < size; i++ {
+		for i := range size {
 			if i%100 == 0 {
 				nodes[i] = N(ntIt)
 			} else {

--- a/internal/ordering_test.go
+++ b/internal/ordering_test.go
@@ -103,7 +103,7 @@ var _ = Describe("OrderSpecs", func() {
 				for conf.RandomSeed = 1; conf.RandomSeed < 10; conf.RandomSeed += 1 {
 					groupedSpecIndices, serialSpecIndices := internal.OrderSpecs(specs, conf)
 					Ω(serialSpecIndices).Should(BeEmpty())
-					for i := 0; i < 10; i++ {
+					for range 10 {
 						reshuffledGroupedSpecIndices, serialSpecIndices := internal.OrderSpecs(specs, conf)
 						Ω(serialSpecIndices).Should(BeEmpty())
 

--- a/internal/output_interceptor_test.go
+++ b/internal/output_interceptor_test.go
@@ -18,7 +18,7 @@ var _ = Describe("OutputInterceptor", func() {
 
 	sharedInterceptorTests := func() {
 		It("intercepts output", func() {
-			for i := 0; i < 2048; i++ { //we loop here to stress test and make sure we aren't leaking any file descriptors
+			for range 2048 { //we loop here to stress test and make sure we aren't leaking any file descriptors
 				interceptor.StartInterceptingOutput()
 				fmt.Println("hi stdout")
 				fmt.Fprintln(os.Stderr, "hi stderr")
@@ -39,7 +39,7 @@ var _ = Describe("OutputInterceptor", func() {
 
 		It("is stable across multiple shutdowns", func() {
 			numRoutines := runtime.NumGoroutine()
-			for i := 0; i < 2048; i++ { //we loop here to stress test and make sure we aren't leaking any file descriptors
+			for range 2048 { //we loop here to stress test and make sure we aren't leaking any file descriptors
 				interceptor.StartInterceptingOutput()
 				fmt.Println("hi stdout")
 				fmt.Fprintln(os.Stderr, "hi stderr")

--- a/internal/parallel_support/client_server_test.go
+++ b/internal/parallel_support/client_server_test.go
@@ -30,7 +30,6 @@ func (s ColorableStringerStruct) ColorableString() string {
 
 var _ = Describe("The Parallel Support Client & Server", func() {
 	for _, protocol := range []string{"RPC", "HTTP"} {
-		protocol := protocol
 		Describe(fmt.Sprintf("The %s protocol", protocol), Label(protocol), func() {
 			var (
 				server   parallel_support.Server

--- a/internal/test_helpers/docs.go
+++ b/internal/test_helpers/docs.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -33,10 +34,8 @@ func (d Docs) DocWithName(name string) Doc {
 
 func (d Docs) DocWithURL(url string) Doc {
 	for _, doc := range d {
-		for _, u := range doc.URLs {
-			if u == url {
-				return doc
-			}
+		if slices.Contains(doc.URLs, url) {
+			return doc
 		}
 	}
 	return Doc{}
@@ -74,13 +73,7 @@ func (a Anchors) IsResolvable(docName string, link string) bool {
 		anchorSet = a.DocAnchors[doc.Name]
 	}
 
-	for _, anchor := range anchorSet {
-		if anchor == expectedAnchor {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(anchorSet, expectedAnchor)
 }
 
 func LoadAnchors(docs Docs, rootPath string) (Anchors, error) {

--- a/internal/test_helpers/run_tracker.go
+++ b/internal/test_helpers/run_tracker.go
@@ -132,10 +132,7 @@ func (m *HaveTrackedMatcher) Match(actual any) (bool, error) {
 		return false, fmt.Errorf("HaveTracked() must be passed a RunTracker - got %T instead", actual)
 	}
 	actualRuns := rt.TrackedRuns()
-	n := len(actualRuns)
-	if n < len(m.expectedRuns) {
-		n = len(m.expectedRuns)
-	}
+	n := max(len(actualRuns), len(m.expectedRuns))
 	failureMessage, success := &strings.Builder{}, true
 	fmt.Fprintf(failureMessage, "{{/}}%10s == %-10s{{/}}\n", "Actual", "Expected")
 	fmt.Fprintf(failureMessage, "{{/}}========================\n{{/}}")

--- a/types/config.go
+++ b/types/config.go
@@ -669,9 +669,9 @@ func GenerateGoTestCompileArgs(goFlagsConfig GoFlagsConfig, packageToBuild strin
 		adjustedCoverPkgs := make([]string, len(coverPkgs))
 		for i, coverPkg := range coverPkgs {
 			coverPkg = strings.Trim(coverPkg, " ")
-			if strings.HasPrefix(coverPkg, "./") {
+			if after, ok := strings.CutPrefix(coverPkg, "./"); ok {
 				// this is a relative coverPkg - we need to reroot it
-				adjustedCoverPkgs[i] = "./" + filepath.Join(pathToInvocationPath, strings.TrimPrefix(coverPkg, "./"))
+				adjustedCoverPkgs[i] = "./" + filepath.Join(pathToInvocationPath, after)
 			} else {
 				// this is a package name - don't touch it
 				adjustedCoverPkgs[i] = coverPkg

--- a/types/flags.go
+++ b/types/flags.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -60,11 +61,8 @@ func (f GinkgoFlags) WithPrefix(prefix string) GinkgoFlags {
 func (f GinkgoFlags) SubsetWithNames(names ...string) GinkgoFlags {
 	out := GinkgoFlags{}
 	for _, flag := range f {
-		for _, name := range names {
-			if flag.Name == name {
-				out = append(out, flag)
-				break
-			}
+		if slices.Contains(names, flag.Name) {
+			out = append(out, flag)
 		}
 	}
 	return out

--- a/types/label_filter.go
+++ b/types/label_filter.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -24,12 +25,7 @@ func matchLabelAction(label string) LabelFilter {
 
 func matchLabelRegexAction(regex *regexp.Regexp) LabelFilter {
 	return func(labels []string) bool {
-		for i := range labels {
-			if regex.MatchString(labels[i]) {
-				return true
-			}
-		}
-		return false
+		return slices.ContainsFunc(labels, regex.MatchString)
 	}
 }
 

--- a/types/report_entry.go
+++ b/types/report_entry.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -180,11 +181,5 @@ func (rev ReportEntryVisibility) MarshalJSON() ([]byte, error) {
 }
 
 func (v ReportEntryVisibility) Is(visibilities ...ReportEntryVisibility) bool {
-	for _, visibility := range visibilities {
-		if v == visibility {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(visibilities, v)
 }


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...