### PR TITLE
Container-aware GOMAXPROCS is available in golang 1.25

### DIFF
--- a/ginkgo/main.go
+++ b/ginkgo/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	_ "go.uber.org/automaxprocs"
 	"github.com/onsi/ginkgo/v2/ginkgo/build"
 	"github.com/onsi/ginkgo/v2/ginkgo/command"
 	"github.com/onsi/ginkgo/v2/ginkgo/generators"

--- a/ginkgo/maxprocs.go
+++ b/ginkgo/maxprocs.go
@@ -1,0 +1,8 @@
+//go:build go1.23 || go1.24
+// +build go1.23 go1.24
+
+package main
+
+import (
+	_ "go.uber.org/automaxprocs"
+)


### PR DESCRIPTION
The support for supporting better GOMAXPROCS using  `"go.uber.org/automaxprocs"` was added in:
https://github.com/onsi/ginkgo/pull/1545

this is not needed in golang 1.25 onwards:
https://go.dev/doc/go1.25#container-aware-gomaxprocs

So let's just ensure we use it only for 1.23 and 1.24 (since the base go.mod is 1.23) and skip it for any other golang versions above those.