### PR TITLE
Bug Fix: Add GinkoTBWrapper.Attr() and GinkoTBWrapper.Output()

### DIFF
--- a/ginkgo_t_dsl.go
+++ b/ginkgo_t_dsl.go
@@ -190,3 +190,9 @@ func (g *GinkgoTBWrapper) Skipped() bool {
 func (g *GinkgoTBWrapper) TempDir() string {
 	return g.GinkgoT.TempDir()
 }
+func (g *GinkgoTBWrapper) Attr(key, value string) {
+	g.GinkgoT.Attr(key, value)
+}
+func (g *GinkgoTBWrapper) Output() io.Writer {
+	return g.GinkgoT.Output()
+}


### PR DESCRIPTION
Add `Attr()` and `Output()` to `GinkgoTBWrapper`. `GinkoTB().Output()` is currently causing `runtime error: invalid memory address or nil pointer dereference`

Related:
- https://github.com/onsi/ginkgo/commit/0a618d45