### PR TITLE
CurrentTreeConstructionNodeReport: fix for nested container nodes

### DIFF
--- a/internal/node_test.go
+++ b/internal/node_test.go
@@ -2119,7 +2119,28 @@ var _ = Describe("ConstructionNodeReport", func() {
 			actual := CurrentTreeConstructionNodeReport()
 			expect := newConstructionNodeReport(expectDescribeReport, []container{{"outer", outerLine + 1, []string{}, []string{}}, {"inner", outerLine + 2, []string{}, []string{}}})
 			expectEqual(actual, expect)
+
+			// The transformer runs while constructing the following It node.
+			// The assertion must be set up outside of it, after removing the transformer.
+			// The report must be the same.
+			remove := AddTreeConstructionNodeArgsTransformer(func(nodeType types.NodeType, offset Offset, text string, args []any) (string, []any, []error) {
+				actual = CurrentTreeConstructionNodeReport()
+				return text, args, nil
+			})
+			It("", func() {})
+			remove()
+			expectEqual(actual, expect)
 		})
+
+		var actual ConstructionNodeReport
+		expect := newConstructionNodeReport(expectDescribeReport, []container{{"outer", outerLine + 1, []string{}, []string{}}})
+		remove := AddTreeConstructionNodeArgsTransformer(func(nodeType types.NodeType, offset Offset, text string, args []any) (string, []any, []error) {
+			actual = CurrentTreeConstructionNodeReport()
+			return text, args, nil
+		})
+		It("", func() {})
+		remove()
+		expectEqual(actual, expect)
 	})
 })
 

--- a/internal/suite.go
+++ b/internal/suite.go
@@ -208,9 +208,12 @@ func (suite *Suite) PushNode(node Node) error {
 
 				// Ensure that code running in the body of the container node
 				// has access to information about the current container node(s).
+				// The current one (nil in top-level container nodes, non-nil in an
+				// embedded container node) gets restored when the node is done.
+				oldConstructionNodeReport := suite.currentConstructionNodeReport
 				suite.currentConstructionNodeReport = constructionNodeReportForTreeNode(suite.tree)
 				defer func() {
-					suite.currentConstructionNodeReport = nil
+					suite.currentConstructionNodeReport = oldConstructionNodeReport
 				}()
 
 				node.Body(nil)


### PR DESCRIPTION
In the following tree, the code cleaning up after the inner container node set a nil current construction node report, causing
CurrentTreeConstructionNodeReport to panic with "CurrentConstructionNodeReport may only be called during construction of the spec tree" when called by the transformer for the following It:

    var _ = Describe("outer", func() {
        Context("inner", func() {
            ...
        })
        It("works", func() { ... })
    })

The fix is to restore the old value instead of setting to nil.

Found when using the new functionality for real in https://github.com/kubernetes/kubernetes/pull/134708. The fix has been tested there.