### PR TITLE
Fix doclink for ginkgo run

### DIFF
--- a/ginkgo/run/run_command.go
+++ b/ginkgo/run/run_command.go
@@ -33,7 +33,7 @@ func BuildRunCommand() command.Command {
 		Usage:         "ginkgo run <FLAGS> <PACKAGES> -- <PASS-THROUGHS>",
 		ShortDoc:      "Run the tests in the passed in <PACKAGES> (or the package in the current directory if left blank)",
 		Documentation: "Any arguments after -- will be passed to the test.",
-		DocLink:       "running-tests",
+		DocLink:       "running-specs",
 		Command: func(args []string, additionalArgs []string) {
 			var errors []error
 			cliConfig, goFlagsConfig, errors = types.VetAndInitializeCLIAndGoConfig(cliConfig, goFlagsConfig)


### PR DESCRIPTION
The doclink for `ginkgo run` points to a nonexistent heading, `#running-tests`. Looks like it was renamed to `#running-specs`.

Let me know if you'd rather I opened an issue - thought this was a tiny enough change not to warrant one