### PR TITLE
Add ArtifactDir() to support Go 1.26 testing.TB interface

### DIFF
--- a/ginkgo_t_dsl.go
+++ b/ginkgo_t_dsl.go
@@ -72,6 +72,7 @@ type GinkgoTInterface interface {
 	TempDir() string
 	Attr(key, value string)
 	Output() io.Writer
+	ArtifactDir() string
 }
 
 /*
@@ -195,4 +196,7 @@ func (g *GinkgoTBWrapper) Attr(key, value string) {
 }
 func (g *GinkgoTBWrapper) Output() io.Writer {
 	return g.GinkgoT.Output()
+}
+func (g *GinkgoTBWrapper) ArtifactDir() string {
+	return g.GinkgoT.ArtifactDir()
 }

--- a/internal/testingtproxy/testing_t_proxy.go
+++ b/internal/testingtproxy/testing_t_proxy.go
@@ -181,6 +181,15 @@ func (t *ginkgoTestingTProxy) TempDir() string {
 	return tmpDir
 }
 
+func (t *ginkgoTestingTProxy) ArtifactDir() string {
+	artifactDir, err := os.MkdirTemp("", "ginkgo")
+	if err != nil {
+		t.fail(fmt.Sprintf("Failed to create artifact directory: %v", err), 1)
+		return ""
+	}
+	return artifactDir
+}
+
 // FullGinkgoTInterface
 func (t *ginkgoTestingTProxy) AddReportEntryVisibilityAlways(name string, args ...any) {
 	finalArgs := []any{internal.Offset(1), types.ReportEntryVisibilityAlways}


### PR DESCRIPTION
Go 1.26 added `ArtifactDir() string` to the `testing.TB` interface. This adds the method to `GinkgoTInterface`, `GinkgoTBWrapper`, and `ginkgoTestingTProxy` to maintain compatibility.

The implementation creates a temporary directory (similar to `TempDir()`) but without automatic cleanup, matching the semantics of `testing.T.ArtifactDir()` which provides a persistent directory for test artifacts.

Fixes #1640