### PR TITLE
Add asan CLI option mirroring msan implementation

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -215,6 +215,7 @@ type GoFlagsConfig struct {
 	N             bool
 	ModFile       string
 	ModCacheRW    bool
+	ASan          bool
 	MSan          bool
 	PkgDir        string
 	Tags          string
@@ -570,6 +571,8 @@ var GoBuildFlags = GinkgoFlags{
 		Usage: "leave newly-created directories in the module cache read-write instead of making them read-only."},
 	{KeyPath: "Go.ModFile", Name: "modfile", UsageArgument: "file", SectionKey: "go-build",
 		Usage: `in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named go.mod must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".`},
+	{KeyPath: "Go.ASan", Name: "asan", SectionKey: "go-build",
+		Usage: "enable interoperation with address sanitizer."},
 	{KeyPath: "Go.MSan", Name: "msan", SectionKey: "go-build",
 		Usage: "enable interoperation with memory sanitizer. Supported only on linux/amd64, linux/arm64 and only with Clang/LLVM as the host C compiler. On linux/arm64, pie build mode will be used."},
 	{KeyPath: "Go.N", Name: "n", SectionKey: "go-build",


### PR DESCRIPTION
Address sanitizer was introduced in Go 1.18