### PR TITLE
Implement shell completion

### DIFF
--- a/ginkgo/command/program.go
+++ b/ginkgo/command/program.go
@@ -1,9 +1,13 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2/formatter"
@@ -156,6 +160,166 @@ func (p Program) handleHelpRequestsAndExit(writer io.Writer, args []string) {
 		p.EmitUsage(writer)
 		Abort(AbortDetails{ExitCode: 1})
 	}
+}
+
+type completionOptions = struct {
+	Complete bool
+	Install  bool
+}
+
+func (p *Program) BuildCompletionCommand() Command {
+	opts := completionOptions{}
+	flags, err := types.NewGinkgoFlagSet(
+		types.GinkgoFlags{
+			{Name: "complete", KeyPath: "Complete", Usage: "Generate completion for arguments after --"},
+			{Name: "install", KeyPath: "Install", Usage: "Install shell completion script into $XDG_DATA_HOME, ~/.local/share"},
+		},
+		&opts,
+		types.GinkgoFlagSections{},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return Command{
+		Name:     "completion",
+		Usage:    "ginkgo completion <FLAGS> <SHELL> [-- <COMPLETE>]",
+		Flags:    flags,
+		ShortDoc: "Generate shell completion",
+		Documentation: `To use install completion script for your shell (bash, fish, zsh).
+Or load completion code by: {{bold}}source <(ginkgo completion <SHELL>){{/}}.`,
+		Command: func(args []string, completeArgs []string) {
+			p.handleCompletionAndExit(args, completeArgs, opts)
+		},
+	}
+}
+
+func (p Program) generateShellCompletionScript(shell string) (scriptPath string, script string) {
+	switch shell {
+	case "bash":
+		scriptPath = fmt.Sprintf("bash-completion/completions/%s", p.Name)
+		script = fmt.Sprintf(`__%s_complete_bash() {
+  mapfile -t COMPREPLY < <("${COMP_WORDS[0]}" completion --complete bash -- "${COMP_WORDS[@]:1:COMP_CWORD}")
+}
+complete -o bashdefault -o default -F __%[1]s_complete_bash %[1]s
+`, p.Name)
+
+	case "fish":
+		scriptPath = fmt.Sprintf("fish/vendor_completions.d/%s.fish", p.Name)
+		script = fmt.Sprintf(`function __fish_%[1]s_complete
+  set -l args (commandline -opc) (commandline -ct)
+  set -e args[1]
+  %[1]s completion --complete fish -- $args
+end
+complete -c %[1]s -a "(__fish_%[1]s_complete)"
+`, p.Name)
+
+	case "zsh":
+		scriptPath = fmt.Sprintf("zsh/site-functions/_%s", p.Name)
+		script = fmt.Sprintf(`#compdef %[1]s
+_%[1]s() {
+  local -a completions
+  completions=(${(f)"$("${words[1]}" completion --complete zsh -- "${words[@]:1:$((CURRENT-1))}")"})
+  if (( ${#completions[@]} )); then
+    _describe 'completions' completions
+  else
+    _default
+  fi
+}
+compdef _%[1]s %[1]s
+if [ "$funcstack[1]" = "_%[1]s" ]; then
+  _%[1]s
+fi
+`, p.Name)
+
+	case "":
+		AbortWithUsage("Shell is not specified")
+	default:
+		AbortWith("Shell %q is not supported yet. Choose: bash, fish, zsh", shell)
+	}
+
+	return scriptPath, script
+}
+
+func (p Program) handleCompletionAndExit(args, completeArgs []string, opts completionOptions) {
+	writer := p.OutWriter
+	if writer == nil {
+		writer = os.Stdout
+	}
+	buffer := bufio.NewWriter(writer)
+	defer buffer.Flush()
+
+	var shell string
+	if len(args) > 0 {
+		shell = args[0]
+	}
+
+	if !opts.Complete {
+		scriptPath, script := p.generateShellCompletionScript(shell)
+		if opts.Install {
+			dataHomeDir := os.Getenv("XDG_DATA_HOME")
+			if dataHomeDir == "" {
+				userHomeDir, err := os.UserHomeDir()
+				AbortIfError("Failed to find home", err)
+				dataHomeDir = filepath.Join(userHomeDir, ".local/share")
+			}
+			scriptPath = filepath.Join(dataHomeDir, scriptPath)
+			fmt.Fprintf(buffer, "Installing completion script: %v\n", scriptPath)
+			err := os.WriteFile(scriptPath, []byte(script), 0644)
+			AbortIfError("Failed to install completion script", err)
+		} else {
+			buffer.Write([]byte(script))
+		}
+		Abort(AbortDetails{})
+	}
+
+	var lastArg string
+	var result map[string]string
+	if len(completeArgs) > 0 {
+		lastArg = completeArgs[len(completeArgs)-1]
+	}
+
+	if delim := slices.Index(completeArgs, "--"); delim >= 0 && delim != len(completeArgs)-1 {
+		// No completion for pass-through arguments after "--"
+	} else if len(lastArg) > 0 && lastArg[0] == '-' {
+		// Complete flags
+		cmd := &p.DefaultCommand
+		for i := range p.Commands {
+			if p.Commands[i].Name == completeArgs[0] {
+				cmd = &p.Commands[i]
+				break
+			}
+		}
+		result = cmd.Flags.Completion(lastArg)
+	} else if len(completeArgs) <= 1 {
+		// Complete commands
+		result = make(map[string]string, len(p.Commands)+1)
+		for _, cmd := range append(p.Commands, p.DefaultCommand) {
+			if strings.HasPrefix(cmd.Name, lastArg) {
+				result[cmd.Name] = cmd.Usage
+			}
+		}
+	}
+
+	width := 0
+	for suggest := range result {
+		width = max(width, len(suggest))
+	}
+
+	for _, suggest := range slices.Sorted(maps.Keys(result)) {
+		usage := result[suggest]
+		switch {
+		case shell == "bash" && usage != "" && len(result) > 1:
+			fmt.Fprintf(buffer, "%*s (%s)\n", -width-2, suggest, usage)
+		case shell == "fish":
+			fmt.Fprintf(buffer, "%s\t%s\n", suggest, usage)
+		case shell == "zsh":
+			fmt.Fprintf(buffer, "%s:%s\n", suggest, usage)
+		default:
+			fmt.Fprintln(buffer, suggest)
+		}
+	}
+
+	Abort(AbortDetails{})
 }
 
 func (p Program) EmitUsage(writer io.Writer) {

--- a/ginkgo/command/program_test.go
+++ b/ginkgo/command/program_test.go
@@ -320,4 +320,100 @@ var _ = Describe("Program", func() {
 		})
 	})
 
+	Context("completion subcommand", func() {
+		BeforeEach(func() {
+			program.Commands = append(program.Commands, program.BuildCompletionCommand())
+		})
+
+		Context("when completing the subcommand position with no args", func() {
+			BeforeEach(func() {
+				program.RunAndExit([]string{"omicron", "completion", "--complete", "bash", "--"})
+			})
+
+			It("lists all command names", func() {
+				Ω(rt).Should(HaveTracked("exit"))
+				Ω(rt).Should(HaveRunWithData("exit", "Code", 0))
+				output := strings.Split(string(buf.Contents()), "\n")
+				Ω(output).Should(HaveExactElements(
+					HavePrefix("alpha "),
+					HavePrefix("beta "),
+					HavePrefix("completion "),
+					"gamma",
+					"zeta",
+					"",
+				))
+			})
+		})
+
+		Context("when completing the subcommand position with a partial arg", func() {
+			BeforeEach(func() {
+				program.RunAndExit([]string{"omicron", "completion", "--complete", "bash", "--", "be"})
+			})
+
+			It("lists only matching command names", func() {
+				Ω(rt).Should(HaveTracked("exit"))
+				Ω(rt).Should(HaveRunWithData("exit", "Code", 0))
+				output := string(buf.Contents())
+				Ω(output).Should(Equal("beta\n"))
+			})
+		})
+
+		DescribeTableSubtree("when completing flags for a known subcommand",
+			func(shell, result string) {
+				BeforeEach(func() {
+					program.RunAndExit([]string{"omicron", "completion", "--complete", shell, "--", "beta", "--"})
+				})
+
+				It("lists flags for that subcommand", func() {
+					Ω(rt).Should(HaveTracked("exit"))
+					Ω(rt).Should(HaveRunWithData("exit", "Code", 0))
+					Ω(string(buf.Contents())).Should(Equal(result))
+				})
+			},
+			Entry("bash", "bash", "--decay-rate\n"),
+			Entry("fish", "fish", "--decay-rate\tset the decay rate, in years\n"),
+			Entry("zsh", "zsh", "--decay-rate:set the decay rate, in years\n"),
+		)
+
+		Context("when completing flags for a known subcommand with one dash", func() {
+			BeforeEach(func() {
+				program.RunAndExit([]string{"omicron", "completion", "--complete", "bash", "--", "beta", "-"})
+			})
+
+			It("lists flags for that subcommand with one dash", func() {
+				Ω(rt).Should(HaveTracked("exit"))
+				Ω(rt).Should(HaveRunWithData("exit", "Code", 0))
+				output := string(buf.Contents())
+				Ω(output).Should(Equal("-decay-rate\n"))
+			})
+		})
+
+		Context("when completing flags for default subcommand", func() {
+			BeforeEach(func() {
+				program.RunAndExit([]string{"omicron", "completion", "--complete", "bash", "--", "--"})
+			})
+
+			It("lists flags for default subcommand", func() {
+				Ω(rt).Should(HaveTracked("exit"))
+				Ω(rt).Should(HaveRunWithData("exit", "Code", 0))
+				output := string(buf.Contents())
+				Ω(output).Should(Equal(""))
+			})
+		})
+
+		Context("when completing pass-through arguments", func() {
+			BeforeEach(func() {
+				program.RunAndExit([]string{"omicron", "completion", "--complete", "bash", "--", "run", "--", "--"})
+			})
+
+			It("outputs nothing", func() {
+				Ω(rt).Should(HaveTracked("exit"))
+				Ω(rt).Should(HaveRunWithData("exit", "Code", 0))
+				output := string(buf.Contents())
+				Ω(output).Should(Equal(""))
+			})
+		})
+
+	})
+
 })

--- a/ginkgo/main.go
+++ b/ginkgo/main.go
@@ -41,6 +41,7 @@ func main() {
 			{Name: "nodot", Deprecation: types.Deprecations.Nodot()},
 		},
 	}
+	program.Commands = append(program.Commands, program.BuildCompletionCommand())
 
 	program.RunAndExit(os.Args)
 }

--- a/types/flags.go
+++ b/types/flags.go
@@ -212,6 +212,24 @@ func (f GinkgoFlagSet) IsZero() bool {
 	return f.flagSet == nil
 }
 
+func (f GinkgoFlagSet) Completion(arg string) map[string]string {
+	if f.IsZero() {
+		return nil
+	}
+	prefix := strings.TrimLeft(arg, "-")
+	dash := arg[:len(arg)-len(prefix)]
+	if len(dash) < 1 || len(dash) > 3 {
+		return nil
+	}
+	result := make(map[string]string, len(f.flags))
+	for _, flag := range f.flags {
+		if flag.Name != "" && strings.HasPrefix(flag.Name, prefix) {
+			result[dash+flag.Name] = flag.Usage
+		}
+	}
+	return result
+}
+
 func (f GinkgoFlagSet) WasSet(name string) bool {
 	found := false
 	f.flagSet.Visit(func(f *flag.Flag) {


### PR DESCRIPTION
This adds subcommand "completion" to the CLI which:
- generates completion script: ginkgo completion bash
- installs completion script: ginkgo completion --install bash
- generates commands completion: ginkgo completion --complete bash --
- generates flags completion: ginkgo completion --complete bash -- run --
- without suggests script fails back to default and completes file paths

For "bash" use hack similar to used in cobra, but implement it in go:
- single suggests are issued as is without description
- multiple suggests are issued in form "{suggest}{align}({description})" I.e. description is a part of suggest but shell will use only common prefix.

For "zsh" issue completion response in form "{suggest}:{description}".

For "fish" issue completion response in form "{suggest}\t{description}".