### PR TITLE
Fix nested --github-output group for progress report nested inside timeline

### DIFF
--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -423,7 +423,7 @@ func (r *DefaultReporter) emitTimeline(indent uint, report types.SpecReport, tim
 		case types.ReportEntry:
 			r.emitReportEntry(indent, x)
 		case types.ProgressReport:
-			r.emitProgressReport(indent, false, isVeryVerbose, x)
+			r.emitProgressReport(indent, isVeryVerbose, false, x)
 		case types.SpecEvent:
 			if isVeryVerbose || !x.IsOnlyVisibleAtVeryVerbose() || r.conf.ShowNodeEvents {
 				r.emitSpecEvent(indent, x, isVeryVerbose)
@@ -533,6 +533,7 @@ func (r *DefaultReporter) emitProgressReport(indent uint, emitGinkgoWriterOutput
 		indent -= 1
 	}
 
+	// Emit only top-level groups because github logging cannot handle nested groups correctly.
 	if r.conf.GithubOutput && emitGroup {
 		r.emitBlock(r.fi(indent, "::group::Progress Report"))
 	}


### PR DESCRIPTION
Do not emit group when progress report is nested in timeline or failure.
Unfortunately github logging does not handle nested groups correctly.

Commit 606c1cb29be1b5e06c502e022559fb59e34d1629 passed "isVeryVerbose" as
to argument "emitGroup", while should pass to "emitGinkgoWriterOutput".
So, it break fix added in commit fdc65b13166ea27ef283a055289bfe3719318b17.