### PR TITLE
chore: refactor devcontainer for better maintenance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,10 +25,8 @@
         "RUBYOPT": "-rbigdecimal"
     },
     "postCreateCommand": {
-        "first-run-notice": "sudo mkdir -p /workspaces/.codespaces/shared && echo \"use 'serve-docs' command to serve Github pages documentation on http://127.0.0.1:4000/ginkgo\" | sudo tee -a /workspaces/.codespaces/shared/first-run-notice.txt",
-        "off-rails": "cd docs && bundle install && gem install bigdecimal",
-        "ginkgotest": "sudo bash -c 'cat >/usr/local/bin/ginkgotest <<\"EOF\"\n#!/usr/bin/env bash\nset -e\n\ngo run ./ginkgo --github-output -r -randomize-all -randomize-suites -race -trace -procs=2 -poll-progress-after=10s -poll-progress-interval=10s\nEOF\nchmod +x /usr/local/bin/ginkgotest'",
-        "serve-docs": "sudo bash -c 'cat >/usr/local/bin/serve-docs <<\"EOF\"\n#!/usr/bin/env bash\nset -e\n\nPWD_REAL=\"$(pwd)\"\n\ncase \"$PWD_REAL\" in\n  /workspaces/*)\n    ;;\n  *)\n    echo \"Not inside a VS Code devcontainer workspace: $PWD_REAL\"\n    exit 1\n    ;;\nesac\n\nWORKSPACE_ROOT=\"$(echo \"$PWD_REAL\" | cut -d/ -f1-3)\"\nDOCS_DIR=\"$WORKSPACE_ROOT/docs\"\n\nif [ ! -d \"$DOCS_DIR\" ]; then\n  echo \"docs directory not found: $DOCS_DIR\"\n  exit 1\nfi\n\ncd \"$DOCS_DIR\"\nexec bundle exec jekyll serve \"$@\"\nEOF\nchmod +x /usr/local/bin/serve-docs'"
+        "finalizing-devcontainer": "sudo .devcontainer/install.sh",
+        "off-rails": "cd docs && bundle install && gem install bigdecimal"
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/first-run-notice.ansi
+++ b/.devcontainer/first-run-notice.ansi
@@ -1,0 +1,2 @@
+* [1mginkgotest[22m runs the full test suite.
+* [1mserve-docs[22m serves Ginkgo Github pages on http://127.0.0.1:4000/ginkgo.

--- a/.devcontainer/ginkgotest
+++ b/.devcontainer/ginkgotest
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+go run github.com/onsi/ginkgo/v2/ginkgo \
+    --github-output \
+    -r --randomize-all --randomize-suites \
+    --race --trace \
+    --procs=2 \
+    --poll-progress-after=10s -poll-progress-interval=10s

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+echo "finalizing devcontainer setup.."
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'script must be run as root.'
+    exit 1
+fi
+
+WSCSSHARED="/workspaces/.codespaces/shared"
+mkdir -p "${WSCSSHARED}"
+cp .devcontainer/first-run-notice.ansi "${WSCSSHARED}/first-run-notice.txt"
+cp .devcontainer/ginkgotest .devcontainer/serve-docs /usr/local/bin
+
+echo "done."

--- a/.devcontainer/serve-docs
+++ b/.devcontainer/serve-docs
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+PWD_REAL="$(pwd)"
+case "${PWD_REAL}" in
+    /workspaces/*)
+        ;;
+    *)
+        echo "not inside a devcontainer workspace: ${PWD_REAL}"
+        exit 1
+        ;;
+esac
+WORKSPACE_ROOT="$(echo "${PWD_REAL}" | cut -d/ -f1-3)"
+DOCS_DIR="${WORKSPACE_ROOT}/docs"
+if [ ! -d "${DOCS_DIR}" ]; then
+    echo "docs directory ${DOCS_DIR} not found"
+    exit 1
+fi
+cd "$DOCS_DIR"
+exec bundle exec jekyll serve "$@"


### PR DESCRIPTION
Sorry for the noise, this is hopefully making maintaining the devcontainer configuration much easier and clearer what's going on. This chore update now uses proper scripts instead of shoehorning non-trivial shell commands into JSON strings.

On top, I've made the first-run-message to be better readable and more comprehensible.

This is now basically the same devcontainer configuration as the Gomega PR, just with the appropriate name changes from Gomega to Ginkgo.