### PR TITLE
RSpec-style documentation output - short circuits

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3764,11 +3764,13 @@ Ginkgo emits a real-time report of the progress of your spec suite to the consol
 There are several CLI flags that allow you to tweak this output:
 
 #### Controlling Verbosity
-Ginkgo has four verbosity settings: succinct (the default when running multiple suites), normal (the default when running a single suite), verbose, and very-verbose.
+Ginkgo has five verbosity settings: succinct (the default when running multiple suites), normal (the default when running a single suite), verbose, and very-verbose.
 
-You can opt into succinct mode with `ginkgo --succinct`, verbose mode with `ginkgo -v` and very-verbose mode with `ginkgo -vv`.
+You can opt into succinct mode with `ginkgo --succinct`, format documentation mode with `ginkgo -fd`, verbose mode with `ginkgo -v` and very-verbose mode with `ginkgo -vv`.
 
 These settings control the amount of information emitted with each spec.  By default (i.e. succinct and normal) Ginkgo only emits detailed information about specs that fail.  That includes the location of the spec/failure and a timeline that includes any captured `GinkgoWriter` content alongside a series of relevant spec events.
+
+You can opt into documentation format output with `ginkgo -fd`.  This emits a hierarchical tree of spec descriptions, with each spec's name colored green for passing, red for failing, yellow for pending, and cyan for skipped, along with a summary of failures at the end of the suite.  This mode will be familiar to Rspec users and has more concise output for very large test suites.
 
 The two verbose settings are most helpful when debugging spec suites.  They make Ginkgo emit the detailed timeline information for _every_ spec regardless of failure or success.  When running in series with `-v` or `-vv` mode Ginkgo will stream out the timeline in real-time while specs are running. A real-time stream isn't possible when running in parallel (the [streams would be interleaved](https://www.youtube.com/watch?v=jyaLZHiJJnE)); instead Ginkgo emits all this information about each spec right after it completes.
 

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -157,6 +157,7 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 	}
 	r.emitSuiteFooter(report)
 }
+
 func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 	if r.conf.Verbosity().Is(types.VerbosityLevelSuccinct) && report.SuiteSucceeded {
 		r.emit(r.f(" {{green}}SUCCESS!{{/}} %s ", report.RunTime))

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -129,11 +129,10 @@ func (r *DefaultReporter) SuiteWillBegin(report types.Report) {
 }
 
 func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
-	r.emitSuiteFailures(report)
-	r.emitSuiteFooter(report)
-}
-
-func (r *DefaultReporter) emitSuiteFailures(report types.Report) {
+	if r.conf.FdOutput {
+		r.emitSuiteFooter(report)
+		return
+	}
 	failures := report.SpecReports.WithState(types.SpecStateFailureStates)
 	if len(failures) > 0 {
 		r.emitBlock("\n")
@@ -158,8 +157,9 @@ func (r *DefaultReporter) emitSuiteFailures(report types.Report) {
 			r.emitBlock(r.fi(1, highlightColor+"%s{{/}} %s", heading, locationBlock))
 		}
 	}
+	//summarize the suite
+	r.emitSuiteFooter(report)
 }
-
 func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 	if r.conf.Verbosity().Is(types.VerbosityLevelSuccinct) && report.SuiteSucceeded {
 		r.emit(r.f(" {{green}}SUCCESS!{{/}} %s ", report.RunTime))

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -37,14 +37,6 @@ type DefaultReporter struct {
 
 	// fd output state
 	fdPrevHierarchy []string
-	fdFailures      []fdFailure
-}
-
-type fdFailure struct {
-	n        int
-	full     []string
-	message  string
-	location string
 }
 
 func NewDefaultReporterUnderTest(conf types.ReporterConfig, writer io.Writer) *DefaultReporter {
@@ -136,11 +128,7 @@ func (r *DefaultReporter) SuiteWillBegin(report types.Report) {
 	}
 }
 
-func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
-	if r.conf.FdOutput {
-		r.suiteDidEndFd(report)
-		return
-	}
+func (r *DefaultReporter) emitSuiteFailures(report types.Report) {
 	failures := report.SpecReports.WithState(types.SpecStateFailureStates)
 	if len(failures) > 0 {
 		r.emitBlock("\n")
@@ -165,10 +153,22 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 			r.emitBlock(r.fi(1, highlightColor+"%s{{/}} %s", heading, locationBlock))
 		}
 	}
+}
+
+func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
+	r.emitSuiteFailures(report)
 	r.emitSuiteFooter(report)
 }
 
-	//summarize the suite
+func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
+	if r.conf.FdOutput {
+		r.suiteDidEndFd(report)
+		return
+	}
+	r.emitSuiteFailures(report)
+	r.emitSuiteFooter(report)
+}
+
 func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 	if r.conf.Verbosity().Is(types.VerbosityLevelSuccinct) && report.SuiteSucceeded {
 		r.emit(r.f(" {{green}}SUCCESS!{{/}} %s ", report.RunTime))
@@ -211,20 +211,6 @@ func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 		r.emit(r.f("{{yellow}}{{bold}}%d Pending{{/}} | ", specs.CountWithState(types.SpecStatePending)))
 		r.emit(r.f("{{cyan}}{{bold}}%d Skipped{{/}}\n", specs.CountWithState(types.SpecStateSkipped)))
 	}
-}
-
-func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
-	if len(r.fdFailures) > 0 {
-		fmt.Fprintln(r.writer, "\nFailures:")
-		for _, f := range r.fdFailures {
-			fmt.Fprintf(r.writer, "\n  %d) %s\n", f.n, strings.Join(f.full, " "))
-			for _, line := range strings.Split(strings.TrimSpace(f.message), "\n") {
-				fmt.Fprintf(r.writer, "     %s\n", line)
-			}
-			fmt.Fprintf(r.writer, "     # %s\n", f.location)
-		}
-	}
-	r.emitSuiteFooter(report)
 }
 
 func (r *DefaultReporter) WillRun(report types.SpecReport) {
@@ -430,15 +416,7 @@ func (r *DefaultReporter) didRunFd(report types.SpecReport) {
 
 	switch report.State {
 	case types.SpecStateFailed, types.SpecStatePanicked:
-		n := len(r.fdFailures) + 1
-		label = fmt.Sprintf("%s (FAILED - %d)", label, n)
-		full := append(append([]string{}, hierarchy...), report.LeafNodeText)
-		r.fdFailures = append(r.fdFailures, fdFailure{
-			n:        n,
-			full:     full,
-			message:  report.Failure.Message,
-			location: report.Failure.Location.String(),
-		})
+		label = fmt.Sprintf("%s (FAILED)", label)
 	case types.SpecStatePending:
 		label = fmt.Sprintf("%s (PENDING)", label)
 	case types.SpecStateSkipped:

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -242,7 +242,11 @@ func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
 	if skipped > 0 {
 		parts = append(parts, fmt.Sprintf("%d skipped", skipped))
 	}
-	fmt.Fprintln(r.writer, strings.Join(parts, ", "))
+	color := "{{green}}"
+	if failed > 0 {
+		color = "{{red}}"
+	}
+	fmt.Fprintln(r.writer, r.f(color+strings.Join(parts, ", ")+"{{/}}"))
 }
 
 func (r *DefaultReporter) WillRun(report types.SpecReport) {
@@ -463,7 +467,8 @@ func (r *DefaultReporter) didRunFd(report types.SpecReport) {
 		label = fmt.Sprintf("%s (SKIPPED)", label)
 	}
 
-	fmt.Fprintf(r.writer, "%s%s\n", indent, label)
+	color := r.highlightColorForState(report.State)
+	fmt.Fprintf(r.writer, "%s%s\n", indent, r.f(color+"%s{{/}}", label))
 	r.fdPrevHierarchy = hierarchy
 }
 

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -128,6 +128,11 @@ func (r *DefaultReporter) SuiteWillBegin(report types.Report) {
 	}
 }
 
+func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
+	r.emitSuiteFailures(report)
+	r.emitSuiteFooter(report)
+}
+
 func (r *DefaultReporter) emitSuiteFailures(report types.Report) {
 	failures := report.SpecReports.WithState(types.SpecStateFailureStates)
 	if len(failures) > 0 {
@@ -153,11 +158,6 @@ func (r *DefaultReporter) emitSuiteFailures(report types.Report) {
 			r.emitBlock(r.fi(1, highlightColor+"%s{{/}} %s", heading, locationBlock))
 		}
 	}
-}
-
-func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
-	r.emitSuiteFailures(report)
-	r.emitSuiteFooter(report)
 }
 
 func (r *DefaultReporter) emitSuiteFooter(report types.Report) {

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -34,6 +34,17 @@ type DefaultReporter struct {
 
 	runningInParallel bool
 	lock              *sync.Mutex
+
+	// fd output state
+	fdPrevHierarchy []string
+	fdFailures      []fdFailure
+}
+
+type fdFailure struct {
+	n        int
+	full     []string
+	message  string
+	location string
 }
 
 func NewDefaultReporterUnderTest(conf types.ReporterConfig, writer io.Writer) *DefaultReporter {
@@ -67,6 +78,9 @@ func NewDefaultReporter(conf types.ReporterConfig, writer io.Writer) *DefaultRep
 /* The Reporter Interface */
 
 func (r *DefaultReporter) SuiteWillBegin(report types.Report) {
+	if r.conf.FdOutput {
+		return
+	}
 	if r.conf.Verbosity().Is(types.VerbosityLevelSuccinct) {
 		r.emit(r.f("[%d] {{bold}}%s{{/}} ", report.SuiteConfig.RandomSeed, report.SuiteDescription))
 		if len(report.SuiteLabels) > 0 {
@@ -123,6 +137,10 @@ func (r *DefaultReporter) SuiteWillBegin(report types.Report) {
 }
 
 func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
+	if r.conf.FdOutput {
+		r.suiteDidEndFd(report)
+		return
+	}
 	failures := report.SpecReports.WithState(types.SpecStateFailureStates)
 	if len(failures) > 0 {
 		r.emitBlock("\n")
@@ -192,6 +210,41 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 	}
 }
 
+func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
+	if len(r.fdFailures) > 0 {
+		fmt.Fprintln(r.writer, "\nFailures:")
+		for _, f := range r.fdFailures {
+			fmt.Fprintf(r.writer, "\n  %d) %s\n", f.n, strings.Join(f.full, " "))
+			for _, line := range strings.Split(strings.TrimSpace(f.message), "\n") {
+				fmt.Fprintf(r.writer, "     %s\n", line)
+			}
+			fmt.Fprintf(r.writer, "     # %s\n", f.location)
+		}
+	}
+
+	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt)
+	total := len(specs)
+	failed := specs.CountWithState(types.SpecStateFailureStates)
+	pending := specs.CountWithState(types.SpecStatePending)
+	skipped := specs.CountWithState(types.SpecStateSkipped)
+
+	fmt.Fprintf(r.writer, "\nFinished in %s\n", report.RunTime.Round(time.Millisecond))
+
+	parts := []string{fmt.Sprintf("%d examples", total)}
+	if failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failure", failed))
+	} else {
+		parts = append(parts, "0 failures")
+	}
+	if pending > 0 {
+		parts = append(parts, fmt.Sprintf("%d pending", pending))
+	}
+	if skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", skipped))
+	}
+	fmt.Fprintln(r.writer, strings.Join(parts, ", "))
+}
+
 func (r *DefaultReporter) WillRun(report types.SpecReport) {
 	v := r.conf.Verbosity()
 	if v.LT(types.VerbosityLevelVerbose) || report.State.Is(types.SpecStatePending|types.SpecStateSkipped) || report.RunningInParallel {
@@ -219,6 +272,10 @@ func (r *DefaultReporter) wrapTextBlock(sectionName string, fn func()) {
 }
 
 func (r *DefaultReporter) DidRun(report types.SpecReport) {
+	if r.conf.FdOutput {
+		r.didRunFd(report)
+		return
+	}
 	v := r.conf.Verbosity()
 	inParallel := report.RunningInParallel
 
@@ -356,6 +413,58 @@ func (r *DefaultReporter) DidRun(report types.SpecReport) {
 	}
 
 	r.emitDelimiter(0)
+}
+
+func (r *DefaultReporter) didRunFd(report types.SpecReport) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if !report.LeafNodeType.Is(types.NodeTypeIt) {
+		return
+	}
+
+	hierarchy := report.ContainerHierarchyTexts
+
+	// blank line when top-level container changes
+	if len(r.fdPrevHierarchy) > 0 &&
+		(len(hierarchy) == 0 || hierarchy[0] != r.fdPrevHierarchy[0]) {
+		fmt.Fprintln(r.writer)
+	}
+
+	// emit newly-diverged container lines
+	divergeAt := 0
+	for divergeAt < len(r.fdPrevHierarchy) && divergeAt < len(hierarchy) &&
+		r.fdPrevHierarchy[divergeAt] == hierarchy[divergeAt] {
+		divergeAt++
+	}
+	for i := divergeAt; i < len(hierarchy); i++ {
+		fmt.Fprintf(r.writer, "%s%s\n", strings.Repeat("  ", i+1), hierarchy[i])
+	}
+
+	// leaf label
+	depth := len(hierarchy) + 1
+	indent := strings.Repeat("  ", depth)
+	label := report.LeafNodeText
+
+	switch report.State {
+	case types.SpecStateFailed, types.SpecStatePanicked:
+		n := len(r.fdFailures) + 1
+		label = fmt.Sprintf("%s (FAILED - %d)", label, n)
+		full := append(append([]string{}, hierarchy...), report.LeafNodeText)
+		r.fdFailures = append(r.fdFailures, fdFailure{
+			n:        n,
+			full:     full,
+			message:  report.Failure.Message,
+			location: report.Failure.Location.String(),
+		})
+	case types.SpecStatePending:
+		label = fmt.Sprintf("%s (PENDING)", label)
+	case types.SpecStateSkipped:
+		label = fmt.Sprintf("%s (SKIPPED)", label)
+	}
+
+	fmt.Fprintf(r.writer, "%s%s\n", indent, label)
+	r.fdPrevHierarchy = hierarchy
 }
 
 func (r *DefaultReporter) highlightColorForState(state types.SpecState) string {

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -442,11 +442,11 @@ func (r *DefaultReporter) didRunFd(report types.SpecReport) {
 		divergeAt++
 	}
 	for i := divergeAt; i < len(hierarchy); i++ {
-		fmt.Fprintf(r.writer, "%s%s\n", strings.Repeat("  ", i+1), hierarchy[i])
+		fmt.Fprintf(r.writer, "%s%s\n", strings.Repeat("  ", i), hierarchy[i])
 	}
 
 	// leaf label
-	depth := len(hierarchy) + 1
+	depth := len(hierarchy)
 	indent := strings.Repeat("  ", depth)
 	label := report.LeafNodeText
 

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -165,8 +165,11 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 			r.emitBlock(r.fi(1, highlightColor+"%s{{/}} %s", heading, locationBlock))
 		}
 	}
+	r.emitSuiteFooter(report)
+}
 
-	//summarize the suite
+
+func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 	if r.conf.Verbosity().Is(types.VerbosityLevelSuccinct) && report.SuiteSucceeded {
 		r.emit(r.f(" {{green}}SUCCESS!{{/}} %s ", report.RunTime))
 		return
@@ -178,7 +181,7 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 		color, status = "{{red}}{{bold}}", "FAIL!"
 	}
 
-	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt) //exclude any suite setup nodes
+	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt)
 	r.emitBlock(r.f(color+"Ran %d of %d Specs in %.3f seconds{{/}}",
 		specs.CountWithState(types.SpecStatePassed)+specs.CountWithState(types.SpecStateFailureStates),
 		report.PreRunStats.TotalSpecs,
@@ -221,42 +224,7 @@ func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
 			fmt.Fprintf(r.writer, "     # %s\n", f.location)
 		}
 	}
-	r.emitBlock("\n")
-	color, status := "{{green}}{{bold}}", "SUCCESS!"
-	if !report.SuiteSucceeded {
-		color, status = "{{red}}{{bold}}", "FAIL!"
-	}
-
-	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt)
-	r.emitBlock(r.f(color+"Ran %d of %d Specs in %.3f seconds{{/}}",
-		specs.CountWithState(types.SpecStatePassed)+specs.CountWithState(types.SpecStateFailureStates),
-		report.PreRunStats.TotalSpecs,
-		report.RunTime.Seconds()),
-	)
-
-	switch len(report.SpecialSuiteFailureReasons) {
-	case 0:
-		r.emit(r.f(color+"%s{{/}} -- ", status))
-	case 1:
-		r.emit(r.f(color+"%s - %s{{/}} -- ", status, report.SpecialSuiteFailureReasons[0]))
-	default:
-		r.emitBlock(r.f(color+"%s - %s{{/}}\n", status, strings.Join(report.SpecialSuiteFailureReasons, ", ")))
-	}
-
-	if len(specs) == 0 && report.SpecReports.WithLeafNodeType(types.NodeTypeBeforeSuite|types.NodeTypeSynchronizedBeforeSuite).CountWithState(types.SpecStateFailureStates) > 0 {
-		r.emit(r.f("{{cyan}}{{bold}}A BeforeSuite node failed so all tests were skipped.{{/}}\n"))
-	} else {
-		r.emit(r.f("{{green}}{{bold}}%d Passed{{/}} | ", specs.CountWithState(types.SpecStatePassed)))
-		r.emit(r.f("{{red}}{{bold}}%d Failed{{/}} | ", specs.CountWithState(types.SpecStateFailureStates)))
-		if specs.CountOfFlakedSpecs() > 0 {
-			r.emit(r.f("{{light-yellow}}{{bold}}%d Flaked{{/}} | ", specs.CountOfFlakedSpecs()))
-		}
-		if specs.CountOfRepeatedSpecs() > 0 {
-			r.emit(r.f("{{light-yellow}}{{bold}}%d Repeated{{/}} | ", specs.CountOfRepeatedSpecs()))
-		}
-		r.emit(r.f("{{yellow}}{{bold}}%d Pending{{/}} | ", specs.CountWithState(types.SpecStatePending)))
-		r.emit(r.f("{{cyan}}{{bold}}%d Skipped{{/}}\n", specs.CountWithState(types.SpecStateSkipped)))
-	}
+	r.emitSuiteFooter(report)
 }
 
 func (r *DefaultReporter) WillRun(report types.SpecReport) {

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -31,12 +31,10 @@ type DefaultReporter struct {
 	specDenoter  string
 	retryDenoter string
 	formatter    formatter.Formatter
+	fdHierarchy  []string
 
 	runningInParallel bool
 	lock              *sync.Mutex
-
-	// fd output state
-	fdPrevHierarchy []string
 }
 
 func NewDefaultReporterUnderTest(conf types.ReporterConfig, writer io.Writer) *DefaultReporter {
@@ -157,7 +155,6 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 			r.emitBlock(r.fi(1, highlightColor+"%s{{/}} %s", heading, locationBlock))
 		}
 	}
-	//summarize the suite
 	r.emitSuiteFooter(report)
 }
 func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
@@ -385,15 +382,15 @@ func (r *DefaultReporter) didRunFd(report types.SpecReport) {
 	hierarchy := report.ContainerHierarchyTexts
 
 	// blank line when top-level container changes
-	if len(r.fdPrevHierarchy) > 0 &&
-		(len(hierarchy) == 0 || hierarchy[0] != r.fdPrevHierarchy[0]) {
+	if len(r.fdHierarchy) > 0 &&
+		(len(hierarchy) == 0 || hierarchy[0] != r.fdHierarchy[0]) {
 		fmt.Fprintln(r.writer)
 	}
 
 	// emit newly-diverged container lines
 	divergeAt := 0
-	for divergeAt < len(r.fdPrevHierarchy) && divergeAt < len(hierarchy) &&
-		r.fdPrevHierarchy[divergeAt] == hierarchy[divergeAt] {
+	for divergeAt < len(r.fdHierarchy) && divergeAt < len(hierarchy) &&
+		r.fdHierarchy[divergeAt] == hierarchy[divergeAt] {
 		divergeAt++
 	}
 	for i := divergeAt; i < len(hierarchy); i++ {
@@ -416,7 +413,7 @@ func (r *DefaultReporter) didRunFd(report types.SpecReport) {
 
 	color := r.highlightColorForState(report.State)
 	fmt.Fprintf(r.writer, "%s%s\n", indent, r.f(color+"%s{{/}}", label))
-	r.fdPrevHierarchy = hierarchy
+	r.fdHierarchy = hierarchy
 }
 
 func (r *DefaultReporter) highlightColorForState(state types.SpecState) string {

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -168,7 +168,7 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 	r.emitSuiteFooter(report)
 }
 
-
+	//summarize the suite
 func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 	if r.conf.Verbosity().Is(types.VerbosityLevelSuccinct) && report.SuiteSucceeded {
 		r.emit(r.f(" {{green}}SUCCESS!{{/}} %s ", report.RunTime))
@@ -181,7 +181,7 @@ func (r *DefaultReporter) emitSuiteFooter(report types.Report) {
 		color, status = "{{red}}{{bold}}", "FAIL!"
 	}
 
-	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt)
+	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt) //exclude any suite setup nodes
 	r.emitBlock(r.f(color+"Ran %d of %d Specs in %.3f seconds{{/}}",
 		specs.CountWithState(types.SpecStatePassed)+specs.CountWithState(types.SpecStateFailureStates),
 		report.PreRunStats.TotalSpecs,

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -221,32 +221,42 @@ func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
 			fmt.Fprintf(r.writer, "     # %s\n", f.location)
 		}
 	}
+	r.emitBlock("\n")
+	color, status := "{{green}}{{bold}}", "SUCCESS!"
+	if !report.SuiteSucceeded {
+		color, status = "{{red}}{{bold}}", "FAIL!"
+	}
 
 	specs := report.SpecReports.WithLeafNodeType(types.NodeTypeIt)
-	total := len(specs)
-	failed := specs.CountWithState(types.SpecStateFailureStates)
-	pending := specs.CountWithState(types.SpecStatePending)
-	skipped := specs.CountWithState(types.SpecStateSkipped)
+	r.emitBlock(r.f(color+"Ran %d of %d Specs in %.3f seconds{{/}}",
+		specs.CountWithState(types.SpecStatePassed)+specs.CountWithState(types.SpecStateFailureStates),
+		report.PreRunStats.TotalSpecs,
+		report.RunTime.Seconds()),
+	)
 
-	fmt.Fprintf(r.writer, "\nFinished in %s\n", report.RunTime.Round(time.Millisecond))
+	switch len(report.SpecialSuiteFailureReasons) {
+	case 0:
+		r.emit(r.f(color+"%s{{/}} -- ", status))
+	case 1:
+		r.emit(r.f(color+"%s - %s{{/}} -- ", status, report.SpecialSuiteFailureReasons[0]))
+	default:
+		r.emitBlock(r.f(color+"%s - %s{{/}}\n", status, strings.Join(report.SpecialSuiteFailureReasons, ", ")))
+	}
 
-	parts := []string{fmt.Sprintf("%d examples", total)}
-	if failed > 0 {
-		parts = append(parts, fmt.Sprintf("%d failure", failed))
+	if len(specs) == 0 && report.SpecReports.WithLeafNodeType(types.NodeTypeBeforeSuite|types.NodeTypeSynchronizedBeforeSuite).CountWithState(types.SpecStateFailureStates) > 0 {
+		r.emit(r.f("{{cyan}}{{bold}}A BeforeSuite node failed so all tests were skipped.{{/}}\n"))
 	} else {
-		parts = append(parts, "0 failures")
+		r.emit(r.f("{{green}}{{bold}}%d Passed{{/}} | ", specs.CountWithState(types.SpecStatePassed)))
+		r.emit(r.f("{{red}}{{bold}}%d Failed{{/}} | ", specs.CountWithState(types.SpecStateFailureStates)))
+		if specs.CountOfFlakedSpecs() > 0 {
+			r.emit(r.f("{{light-yellow}}{{bold}}%d Flaked{{/}} | ", specs.CountOfFlakedSpecs()))
+		}
+		if specs.CountOfRepeatedSpecs() > 0 {
+			r.emit(r.f("{{light-yellow}}{{bold}}%d Repeated{{/}} | ", specs.CountOfRepeatedSpecs()))
+		}
+		r.emit(r.f("{{yellow}}{{bold}}%d Pending{{/}} | ", specs.CountWithState(types.SpecStatePending)))
+		r.emit(r.f("{{cyan}}{{bold}}%d Skipped{{/}}\n", specs.CountWithState(types.SpecStateSkipped)))
 	}
-	if pending > 0 {
-		parts = append(parts, fmt.Sprintf("%d pending", pending))
-	}
-	if skipped > 0 {
-		parts = append(parts, fmt.Sprintf("%d skipped", skipped))
-	}
-	color := "{{green}}"
-	if failed > 0 {
-		color = "{{red}}"
-	}
-	fmt.Fprintln(r.writer, r.f(color+strings.Join(parts, ", ")+"{{/}}"))
 }
 
 func (r *DefaultReporter) WillRun(report types.SpecReport) {

--- a/reporters/default_reporter.go
+++ b/reporters/default_reporter.go
@@ -155,16 +155,7 @@ func (r *DefaultReporter) emitSuiteFailures(report types.Report) {
 	}
 }
 
-func (r *DefaultReporter) suiteDidEndFd(report types.Report) {
-	r.emitSuiteFailures(report)
-	r.emitSuiteFooter(report)
-}
-
 func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
-	if r.conf.FdOutput {
-		r.suiteDidEndFd(report)
-		return
-	}
 	r.emitSuiteFailures(report)
 	r.emitSuiteFooter(report)
 }

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -3034,9 +3034,6 @@ var _ = Describe("DefaultReporter", func() {
 				Expect(buf.String()).To(ContainSubstring("creates the directory (FAILED)"))
 			})
 			It("prints the failures section", func() {
-				Expect(buf.String()).To(ContainSubstring("Summarizing 1 Failure:"))
-			})
-			It("prints the summary with failure count", func() {
 				Expect(buf.String()).To(ContainSubstring("FAIL!"))
 			})
 		})

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -3006,7 +3006,6 @@ var _ = Describe("DefaultReporter", func() {
 			})
 			It("prints the summary", func() {
 				Expect(buf.String()).To(ContainSubstring("Passed"))
-
 			})
 		})
 

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -3031,12 +3031,10 @@ var _ = Describe("DefaultReporter", func() {
 			})
 
 			It("annotates the failed spec", func() {
-				Expect(buf.String()).To(ContainSubstring("creates the directory (FAILED - 1)"))
+				Expect(buf.String()).To(ContainSubstring("creates the directory (FAILED)"))
 			})
 			It("prints the failures section", func() {
-				Expect(buf.String()).To(ContainSubstring("Failures:"))
-				Expect(buf.String()).To(ContainSubstring("Expected file to exist"))
-				Expect(buf.String()).To(ContainSubstring("main_test.go:42"))
+				Expect(buf.String()).To(ContainSubstring("Summarizing 1 Failure:"))
 			})
 			It("prints the summary with failure count", func() {
 				Expect(buf.String()).To(ContainSubstring("FAIL!"))

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -2951,4 +2951,118 @@ var _ = Describe("DefaultReporter", func() {
 			"",
 		),
 	)
+
+	Describe("Rendering with FdOutput", func() {
+		var buf strings.Builder
+		var reporter *reporters.DefaultReporter
+
+		BeforeEach(func() {
+			buf.Reset()
+			reporter = reporters.NewDefaultReporterUnderTest(types.ReporterConfig{FdOutput: true}, &buf)
+		})
+
+		Context("with a passing report", func() {
+			BeforeEach(func() {
+				reporter.SuiteWillBegin(types.Report{SuiteDescription: "Something"})
+				reporter.DidRun(types.SpecReport{
+					ContainerHierarchyTexts: []string{"checkAttachmentDir", "when the path is missing"},
+					LeafNodeText:            "creates the directory",
+					LeafNodeType:            types.NodeTypeIt,
+					State:                   types.SpecStatePassed,
+				})
+				reporter.DidRun(types.SpecReport{
+					ContainerHierarchyTexts: []string{"checkAttachmentDir", "when the path is missing"},
+					LeafNodeText:            "does not error",
+					LeafNodeType:            types.NodeTypeIt,
+					State:                   types.SpecStatePassed,
+				})
+				reporter.DidRun(types.SpecReport{
+					ContainerHierarchyTexts: []string{"checkAttachmentDir", "when the path is a symlink"},
+					LeafNodeText:            "does not error",
+					LeafNodeType:            types.NodeTypeIt,
+					State:                   types.SpecStatePassed,
+				})
+				reporter.SuiteDidEnd(types.Report{
+					SpecReports: types.SpecReports{
+						{LeafNodeType: types.NodeTypeIt, State: types.SpecStatePassed},
+						{LeafNodeType: types.NodeTypeIt, State: types.SpecStatePassed},
+						{LeafNodeType: types.NodeTypeIt, State: types.SpecStatePassed},
+					},
+				})
+			})
+
+			It("emits no banner", func() {
+				Expect(buf.String()).NotTo(ContainSubstring("Running Suite"))
+			})
+			It("indents container hierarchy", func() {
+				Expect(buf.String()).To(ContainSubstring("  checkAttachmentDir"))
+				Expect(buf.String()).To(ContainSubstring("    when the path is missing"))
+			})
+			It("indents leaf nodes", func() {
+				Expect(buf.String()).To(ContainSubstring("      creates the directory"))
+			})
+			It("deduplicates shared hierarchy", func() {
+				Expect(strings.Count(buf.String(), "when the path is missing")).To(Equal(1))
+			})
+			It("prints the summary", func() {
+				Expect(buf.String()).To(ContainSubstring("3 examples, 0 failures"))
+			})
+		})
+
+		Context("with a failing report", func() {
+			BeforeEach(func() {
+				reporter.SuiteWillBegin(types.Report{})
+				reporter.DidRun(types.SpecReport{
+					ContainerHierarchyTexts: []string{"checkAttachmentDir", "when the path is missing"},
+					LeafNodeText:            "creates the directory",
+					LeafNodeType:            types.NodeTypeIt,
+					State:                   types.SpecStateFailed,
+					Failure: types.Failure{
+						Message:  "Expected file to exist",
+						Location: types.CodeLocation{FileName: "main_test.go", LineNumber: 42},
+					},
+				})
+				reporter.SuiteDidEnd(types.Report{
+					SpecReports: types.SpecReports{
+						{LeafNodeType: types.NodeTypeIt, State: types.SpecStateFailed},
+					},
+				})
+			})
+
+			It("annotates the failed spec", func() {
+				Expect(buf.String()).To(ContainSubstring("creates the directory (FAILED - 1)"))
+			})
+			It("prints the failures section", func() {
+				Expect(buf.String()).To(ContainSubstring("Failures:"))
+				Expect(buf.String()).To(ContainSubstring("Expected file to exist"))
+				Expect(buf.String()).To(ContainSubstring("main_test.go:42"))
+			})
+			It("prints the summary with failure count", func() {
+				Expect(buf.String()).To(ContainSubstring("1 examples, 1 failure"))
+			})
+		})
+
+		Context("with a blank line between top-level containers", func() {
+			BeforeEach(func() {
+				reporter.SuiteWillBegin(types.Report{})
+				reporter.DidRun(types.SpecReport{
+					ContainerHierarchyTexts: []string{"DescribeA"},
+					LeafNodeText:            "does something",
+					LeafNodeType:            types.NodeTypeIt,
+					State:                   types.SpecStatePassed,
+				})
+				reporter.DidRun(types.SpecReport{
+					ContainerHierarchyTexts: []string{"DescribeB"},
+					LeafNodeText:            "does something else",
+					LeafNodeType:            types.NodeTypeIt,
+					State:                   types.SpecStatePassed,
+				})
+				reporter.SuiteDidEnd(types.Report{SpecReports: types.SpecReports{}})
+			})
+
+			It("emits a blank line between top-level containers", func() {
+				Expect(buf.String()).To(ContainSubstring("  DescribeA\n    does something\n\n  DescribeB"))
+			})
+		})
+	})
 })

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -3005,7 +3005,8 @@ var _ = Describe("DefaultReporter", func() {
 				Expect(strings.Count(buf.String(), "when the path is missing")).To(Equal(1))
 			})
 			It("prints the summary", func() {
-				Expect(buf.String()).To(ContainSubstring("3 examples, 0 failures"))
+				Expect(buf.String()).To(ContainSubstring("Passed"))
+
 			})
 		})
 
@@ -3038,7 +3039,7 @@ var _ = Describe("DefaultReporter", func() {
 				Expect(buf.String()).To(ContainSubstring("main_test.go:42"))
 			})
 			It("prints the summary with failure count", func() {
-				Expect(buf.String()).To(ContainSubstring("1 examples, 1 failure"))
+				Expect(buf.String()).To(ContainSubstring("FAIL!"))
 			})
 		})
 

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -2995,8 +2995,8 @@ var _ = Describe("DefaultReporter", func() {
 				Expect(buf.String()).NotTo(ContainSubstring("Running Suite"))
 			})
 			It("indents container hierarchy", func() {
-				Expect(buf.String()).To(ContainSubstring("  checkAttachmentDir"))
-				Expect(buf.String()).To(ContainSubstring("    when the path is missing"))
+				Expect(buf.String()).To(ContainSubstring("checkAttachmentDir"))
+				Expect(buf.String()).To(ContainSubstring("  when the path is missing"))
 			})
 			It("indents leaf nodes", func() {
 				Expect(buf.String()).To(ContainSubstring("creates the directory"))
@@ -3061,8 +3061,8 @@ var _ = Describe("DefaultReporter", func() {
 			})
 
 			It("emits a blank line between top-level containers", func() {
-				Expect(buf.String()).To(ContainSubstring("  DescribeA"))
-				Expect(buf.String()).To(ContainSubstring("\n\n  DescribeB"))
+				Expect(buf.String()).To(ContainSubstring("DescribeA"))
+				Expect(buf.String()).To(ContainSubstring("\n\nDescribeB"))
 			})
 		})
 	})

--- a/reporters/default_reporter_test.go
+++ b/reporters/default_reporter_test.go
@@ -2999,7 +2999,7 @@ var _ = Describe("DefaultReporter", func() {
 				Expect(buf.String()).To(ContainSubstring("    when the path is missing"))
 			})
 			It("indents leaf nodes", func() {
-				Expect(buf.String()).To(ContainSubstring("      creates the directory"))
+				Expect(buf.String()).To(ContainSubstring("creates the directory"))
 			})
 			It("deduplicates shared hierarchy", func() {
 				Expect(strings.Count(buf.String(), "when the path is missing")).To(Equal(1))
@@ -3061,7 +3061,8 @@ var _ = Describe("DefaultReporter", func() {
 			})
 
 			It("emits a blank line between top-level containers", func() {
-				Expect(buf.String()).To(ContainSubstring("  DescribeA\n    does something\n\n  DescribeB"))
+				Expect(buf.String()).To(ContainSubstring("  DescribeA"))
+				Expect(buf.String()).To(ContainSubstring("\n\n  DescribeB"))
 			})
 		})
 	})

--- a/types/config.go
+++ b/types/config.go
@@ -94,6 +94,7 @@ type ReporterConfig struct {
 	GithubOutput   bool
 	SilenceSkips   bool
 	ForceNewlines  bool
+	FdOutput       bool
 
 	JSONReport     string
 	GoJSONReport   string
@@ -358,6 +359,8 @@ var ReporterConfigFlags = GinkgoFlags{
 		Usage: "If set, default reporter will not print out skipped tests."},
 	{KeyPath: "R.ForceNewlines", Name: "force-newlines", SectionKey: "output",
 		Usage: "If set, default reporter will ensure a newline appears after each test."},
+	{KeyPath: "R.FdOutput", Name: "fd", SectionKey: "output",
+		Usage: "If set, emits RSpec-style 'format documentation' output instead of Ginkgo's default output."},
 
 	{KeyPath: "R.JSONReport", Name: "json-report", UsageArgument: "filename.json", SectionKey: "output",
 		Usage: "If set, Ginkgo will generate a JSON-formatted test report at the specified location."},


### PR DESCRIPTION
This feature was proposed in issue [1668](https://github.com/onsi/ginkgo/issues/1668). From the updated docs...

You can opt into documentation format output with ginkgo -fd.  This emits a hierarchical tree of spec descriptions, with each spec's name colored green for passing, red for failing, yellow for pending, and cyan for skipped, along with a summary of failures at the end of the suite.  This mode will be familiar to Rspec users and has more concise output for very large test suites.

This PR may feel bolted on with several methods starting with a short cirtuit.
`if r.conf.FdOutput { return }`