### PR TITLE
Allow extensions/globals.Reset to support re-running RunSpecs

### DIFF
--- a/core_dsl.go
+++ b/core_dsl.go
@@ -39,7 +39,6 @@ var flagSet types.GinkgoFlagSet
 var deprecationTracker = types.NewDeprecationTracker()
 var suiteConfig = types.NewDefaultSuiteConfig()
 var reporterConfig = types.NewDefaultReporterConfig()
-var suiteDidRun = false
 var outputInterceptor internal.OutputInterceptor
 var client parallel_support.Client
 
@@ -259,10 +258,10 @@ for more on how specs are parallelized in Ginkgo.
 You can also pass suite-level Label() decorators to RunSpecs.  The passed-in labels will apply to all specs in the suite.
 */
 func RunSpecs(t GinkgoTestingT, description string, args ...any) bool {
-	if suiteDidRun {
+	if global.SuiteDidRun {
 		exitIfErr(types.GinkgoErrors.RerunningSuite())
 	}
-	suiteDidRun = true
+	global.SuiteDidRun = true
 	err := global.PushClone()
 	if err != nil {
 		exitIfErr(err)

--- a/extensions/globals/globals_test.go
+++ b/extensions/globals/globals_test.go
@@ -24,3 +24,18 @@ func TestGlobals(t *testing.T) {
 		t.Error("got the same suite but expected it to be different!")
 	}
 }
+
+func TestResetAllowsRerunningSpecs(t *testing.T) {
+	// RunSpecs refuses to run twice against the same suite, tracked by
+	// global.SuiteDidRun. Reset must clear it alongside the suite itself, so a
+	// program can run several suites sequentially in one process: register specs,
+	// RunSpecs, Reset, register the next suite's specs, RunSpecs again.
+	global.InitializeGlobals()
+
+	global.SuiteDidRun = true
+	globals.Reset()
+
+	if global.SuiteDidRun {
+		t.Error("expected Reset to clear SuiteDidRun so RunSpecs can run a fresh suite")
+	}
+}

--- a/internal/global/init.go
+++ b/internal/global/init.go
@@ -8,6 +8,12 @@ var Suite *internal.Suite
 var Failer *internal.Failer
 var backupSuite *internal.Suite
 
+// SuiteDidRun tracks whether RunSpecs has already been invoked for the current global
+// suite. It lives here (rather than in package ginkgo) so that InitializeGlobals can
+// clear it, allowing extensions/globals.Reset to support running multiple suites
+// sequentially in a single process.
+var SuiteDidRun bool
+
 func init() {
 	InitializeGlobals()
 }
@@ -15,6 +21,7 @@ func init() {
 func InitializeGlobals() {
 	Failer = internal.NewFailer()
 	Suite = internal.NewSuite()
+	SuiteDidRun = false
 }
 
 func PushClone() error {


### PR DESCRIPTION
Closes #1672.

## What

Programs that drive Ginkgo programmatically (merged test binaries for large monorepos, meta-testing of dynamically generated suites) want to run several suites sequentially in one process: register specs, call `RunSpecs`, `Reset`, register the next suite's specs, and call `RunSpecs` again.

Everything `RunSpecs` uses is already either reconstructed per run (reporter, output interceptor, parallel client, progress handler) or reset by `extensions/globals.Reset` (the suite and failer themselves). The one blocker is the `suiteDidRun` guard, which lives in package `ginkgo` where `Reset` cannot reach it, so a second `RunSpecs` always exits with `GinkgoErrors.RerunningSuite`.

This moves the flag into `internal/global` as `SuiteDidRun` and clears it in `InitializeGlobals`. Calling `RunSpecs` twice **without** an intervening `Reset` still fails exactly as before — only an explicit `Reset` arms a fresh run, preserving the accidental-rerun protection. Includes a test in `extensions/globals`.

## Why we want it

At incident.io we compile ~690 monorepo suites into one generated test binary (each per-suite binary was ~350MB of near-identical bytes). With this change, CI worker processes drain a suite queue — `Reset`, re-register, `RunSpecs` — paying process boot once per worker instead of once per suite. Per-suite reporting (`--ginkgo.junit-report` et al) behaves identically to separate processes, and our test phase dropped from ~98s to ~47s. We're currently running this in production CI from a fork pinned via `replace`, and would love to drop the fork.