### PR TITLE
feat: add --sleep-on-failure to pause a failed spec before teardown

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3305,6 +3305,24 @@ One final, somewhat complex, note on timeouts and the Grace Period.  As mentione
 - If the remaining node is interruptible and **does not** have a `NodeTimeout`, Ginkgo uses the Grace Period to set a deadline for the node.  If the deadline expires, then a second Grace Period applies before Ginkgo leaks the node and moves on.
 - If the remaining node is **not** interruptible, Ginkgo will give the node a single Grace Period to complete and exit.  In this case, since it cannot be interrupted, Ginkgo will simply leak the node after one Grace Period.
 
+#### Pausing a Failed Spec for Debugging: The --sleep-on-failure flag
+
+When a spec fails against a real environment (a cluster, database, or service) the spec's teardown - its `AfterEach`, `JustAfterEach`, and `DeferCleanup` nodes - typically tears down the very state you need to inspect to understand the failure.  By the time you can attach a debugger or run `kubectl`/`psql`, the evidence is gone.
+
+The `--sleep-on-failure=<DURATION>` flag pauses a spec **after it fails but before its teardown runs**, leaving the system live so you can perform forensics:
+
+```bash
+ginkgo --sleep-on-failure=30m ./...
+```
+
+With this flag set, the instant a spec fails Ginkgo emits the failure and then pauses for the configured duration before continuing.  The pause happens at the point of failure - before any teardown (`AfterEach`/`JustAfterEach`/`DeferCleanup`) runs - so the failing spec's resources remain in place for you to inspect.  Ginkgo emits a progress report announcing the pause so you know the suite is waiting and what to do next.  Failures that occur in setup and subject nodes (`It`, `BeforeEach`, `BeforeAll`, ...) trigger the pause; failures inside teardown nodes do not, since the system is already being torn down at that point.
+
+The pause is interruptible: pressing `^C` (or otherwise interrupting the suite) ends the pause early and proceeds to run the spec's cleanup nodes - it does not skip teardown.  This means you can pause indefinitely (e.g. `--sleep-on-failure=24h`), inspect the system at your leisure, and then press `^C` once to resume and let Ginkgo clean up.
+
+Specs that pass are never paused, and the flag has no effect when set to `0` (the default).
+
+`--sleep-on-failure` is a debugging aid intended for interactive, serial runs and is **only supported in serial mode**.  Because Ginkgo's parallelism is multi-process, a single failing spec cannot meaningfully freeze the whole system, so combining `--sleep-on-failure` with `-p`/`--procs` is rejected with a configuration error.  Run the specific failing spec serially (for example with `--focus` and without `-p`) when you want to use it.
+
 #### Using SpecContext with Gomega's Eventually
 
 Gomega provides `Eventually` to allow you to poll an object or function repeatedly until a Gomega matcher is satisfied.  `Eventually` integrates cleanly with interruptible nodes by accepting a `SpecContext`/`context.Context` parameter.  This allows you, for example, to enforce a single timeout across a set of polling assertions:

--- a/integration/_fixtures/sleep_on_failure_fixture/sleep_on_failure_fixture_suite_test.go
+++ b/integration/_fixtures/sleep_on_failure_fixture/sleep_on_failure_fixture_suite_test.go
@@ -1,0 +1,13 @@
+package sleep_on_failure_fixture_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSleepOnFailureFixture(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SleepOnFailure Fixture Suite")
+}

--- a/integration/_fixtures/sleep_on_failure_fixture/sleep_on_failure_fixture_test.go
+++ b/integration/_fixtures/sleep_on_failure_fixture/sleep_on_failure_fixture_test.go
@@ -1,0 +1,23 @@
+package sleep_on_failure_fixture_test
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("sleep on failure", func() {
+	It("passes and is never paused", func() {
+		fmt.Fprintln(os.Stdout, "PASSING-SPEC-RAN")
+	})
+
+	It("fails and should be paused before teardown", func() {
+		fmt.Fprintln(os.Stdout, "FAILING-SPEC-BODY-RAN")
+		Fail("intentional failure")
+	})
+
+	AfterEach(func() {
+		fmt.Fprintln(os.Stdout, "TEARDOWN-RAN")
+	})
+})

--- a/integration/sleep_on_failure_test.go
+++ b/integration/sleep_on_failure_test.go
@@ -1,0 +1,65 @@
+package integration_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("--sleep-on-failure", func() {
+	BeforeEach(func() {
+		fm.MountFixture("sleep_on_failure")
+	})
+
+	Context("when running serially with --sleep-on-failure set", func() {
+		It("pauses a failed spec before teardown, then proceeds to teardown", func() {
+			start := time.Now()
+			session := startGinkgo(fm.PathTo("sleep_on_failure"), "--no-color", "--sleep-on-failure=2s")
+			Eventually(session).Should(gexec.Exit(1))
+			elapsed := time.Since(start)
+			output := string(session.Out.Contents())
+
+			// it actually waited for (about) the configured duration
+			Ω(elapsed).Should(BeNumerically(">=", 1500*time.Millisecond), "should have paused for ~2s")
+
+			// it announced the pause and what to do
+			Ω(output).Should(ContainSubstring("Paused on failure"))
+
+			// it paused before teardown: the failing body runs, then the pause, then teardown
+			Ω(output).Should(MatchRegexp(`(?s)FAILING-SPEC-BODY-RAN.*Paused on failure.*TEARDOWN-RAN`),
+				"the pause must occur after the failing spec body and before its teardown")
+
+			// teardown still ran after the pause
+			Ω(output).Should(ContainSubstring("TEARDOWN-RAN"))
+		})
+
+		It("does not pause specs that pass", func() {
+			session := startGinkgo(fm.PathTo("sleep_on_failure"), "--no-color", "--sleep-on-failure=1h", "--focus=passes and is never paused")
+			// if the passing spec were paused, this would hang for an hour; the suite timeout/Eventually guards us
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+			output := string(session.Out.Contents())
+
+			Ω(output).Should(ContainSubstring("PASSING-SPEC-RAN"))
+			Ω(output).ShouldNot(ContainSubstring("Paused on failure"))
+		})
+	})
+
+	Context("when running in parallel with --sleep-on-failure set", func() {
+		It("exits with a helpful error instead of pausing", func() {
+			start := time.Now()
+			session := startGinkgo(fm.PathTo("sleep_on_failure"), "--no-color", "--procs=2", "--sleep-on-failure=1h")
+			Eventually(session).Should(gexec.Exit(1))
+			elapsed := time.Since(start)
+			output := string(session.Out.Contents()) + string(session.Err.Contents())
+
+			// it must not have paused (would have hung for an hour)
+			Ω(elapsed).Should(BeNumerically("<", time.Minute))
+
+			// it explains the serial-only restriction
+			Ω(output).Should(ContainSubstring("Ginkgo only supports --sleep-on-failure in serial mode"))
+			Ω(output).ShouldNot(ContainSubstring("Paused on failure"))
+		})
+	})
+})

--- a/internal/internal_integration/config_sleep_on_failure_test.go
+++ b/internal/internal_integration/config_sleep_on_failure_test.go
@@ -1,0 +1,157 @@
+package internal_integration_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/v2/internal/interrupt_handler"
+	. "github.com/onsi/ginkgo/v2/internal/test_helpers"
+)
+
+var _ = Describe("--sleep-on-failure", func() {
+	Describe("when a spec fails", func() {
+		BeforeEach(func() {
+			conf.SleepOnFailure = 50 * time.Millisecond
+			success, _ := RunFixture("sleep on failure - failing spec", func() {
+				Context("container", func() {
+					BeforeEach(rt.T("bef"))
+					It("A", rt.T("A", func() {
+						DeferCleanup(rt.T("cleanup"))
+						F("boom", cl)
+					}))
+					JustAfterEach(rt.T("just-after"))
+					AfterEach(rt.T("aft"))
+				})
+			})
+			Ω(success).Should(BeFalse())
+		})
+
+		It("pauses at the moment of failure, before any teardown runs", func() {
+			// The pause is hooked into runNode's failure path, so it happens the instant
+			// the It fails - before any JustAfterEach/AfterEach/DeferCleanup nodes run.
+			// Teardown then proceeds in the normal order once the pause elapses.
+			Ω(rt).Should(HaveTracked("bef", "A", "just-after", "aft", "cleanup"))
+		})
+
+		It("still runs teardown and cleanup after the pause", func() {
+			Ω(rt).Should(HaveRun("aft"))
+			Ω(rt).Should(HaveRun("cleanup"))
+		})
+
+		It("emits the failure and then a progress report announcing the pause", func() {
+			Ω(reporter.Did.Find("A")).Should(HaveFailed("boom", cl))
+			Ω(reporter.ProgressReports).ShouldNot(BeEmpty())
+			Ω(reporter.ProgressReports[0].Message).Should(ContainSubstring("Paused on failure"))
+		})
+	})
+
+	Describe("when a failure occurs in a BeforeEach", func() {
+		BeforeEach(func() {
+			conf.SleepOnFailure = 50 * time.Millisecond
+			success, _ := RunFixture("sleep on failure - failing beforeeach", func() {
+				Context("container", func() {
+					BeforeEach(rt.T("bef", func() {
+						F("boom", cl)
+					}))
+					It("A", rt.T("A"))
+					AfterEach(rt.T("aft"))
+				})
+			})
+			Ω(success).Should(BeFalse())
+		})
+
+		It("pauses on the setup failure before teardown, and skips the It", func() {
+			Ω(rt).Should(HaveTracked("bef", "aft"))
+			Ω(reporter.ProgressReports).ShouldNot(BeEmpty())
+			Ω(reporter.ProgressReports[0].Message).Should(ContainSubstring("Paused on failure"))
+		})
+	})
+
+	Describe("when a spec passes", func() {
+		var start time.Time
+		BeforeEach(func() {
+			conf.SleepOnFailure = time.Hour // would hang if it ever fired on success
+			start = time.Now()
+			success, _ := RunFixture("sleep on failure - passing spec", func() {
+				It("A", rt.T("A"))
+				AfterEach(rt.T("aft"))
+			})
+			Ω(success).Should(BeTrue())
+		})
+
+		It("does not pause and emits no pause progress report", func() {
+			Ω(time.Since(start)).Should(BeNumerically("<", time.Second))
+			Ω(rt).Should(HaveTracked("A", "aft"))
+			Ω(reporter.ProgressReports).Should(BeEmpty())
+		})
+	})
+
+	Describe("when a failure occurs in teardown", func() {
+		var start time.Time
+		BeforeEach(func() {
+			conf.SleepOnFailure = time.Hour // would hang if the teardown failure paused
+			start = time.Now()
+			success, _ := RunFixture("sleep on failure - failing teardown", func() {
+				It("A", rt.T("A"))
+				AfterEach(rt.T("aft", func() {
+					F("boom", cl)
+				}))
+			})
+			Ω(success).Should(BeFalse())
+		})
+
+		It("does not pause (teardown is already running, nothing to inspect)", func() {
+			Ω(time.Since(start)).Should(BeNumerically("<", time.Second))
+			Ω(rt).Should(HaveTracked("A", "aft"))
+			Ω(reporter.ProgressReports).Should(BeEmpty())
+		})
+	})
+
+	Describe("when the feature is disabled (duration is zero)", func() {
+		BeforeEach(func() {
+			conf.SleepOnFailure = 0
+			success, _ := RunFixture("sleep on failure - disabled", func() {
+				It("A", rt.T("A", func() {
+					F("boom", cl)
+				}))
+				AfterEach(rt.T("aft"))
+			})
+			Ω(success).Should(BeFalse())
+		})
+
+		It("does not pause and emits no pause progress report", func() {
+			Ω(rt).Should(HaveTracked("A", "aft"))
+			Ω(reporter.ProgressReports).Should(BeEmpty())
+		})
+	})
+
+	Describe("when the user interrupts during the pause", func() {
+		var start time.Time
+		BeforeEach(func() {
+			conf.SleepOnFailure = time.Hour // long enough that only the interrupt can end it
+			start = time.Now()
+			success, _ := RunFixture("sleep on failure - interrupted", func() {
+				Context("container", func() {
+					It("A", rt.T("A", func() {
+						// fire the interrupt shortly after this node's body returns, so it
+						// lands while the suite is paused waiting on the failure
+						go func() {
+							time.Sleep(100 * time.Millisecond)
+							interruptHandler.Interrupt(interrupt_handler.InterruptCauseSignal)
+						}()
+						F("boom", cl)
+					}))
+					AfterEach(rt.T("aft"))
+				})
+			})
+			Ω(success).Should(BeFalse())
+		})
+
+		It("ends the pause early and proceeds to run teardown", func() {
+			Ω(time.Since(start)).Should(BeNumerically("<", time.Minute))
+			Ω(rt).Should(HaveTracked("A", "aft"))
+		})
+	})
+})

--- a/internal/suite.go
+++ b/internal/suite.go
@@ -996,6 +996,7 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 			} else {
 				failure.Message, failure.Location, failure.ForwardedPanic, failure.TimelineLocation = failureFromRun.Message, failureFromRun.Location, failureFromRun.ForwardedPanic, failureFromRun.TimelineLocation
 				suite.reporter.EmitFailure(outcomeFromRun, failure)
+				suite.pauseOnFailureIfRequested(node)
 				return outcomeFromRun, failure
 			}
 		case <-gracePeriodChannel:
@@ -1076,6 +1077,42 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 				progressPoller.Reset(pollProgressInterval)
 			}
 		}
+	}
+}
+
+// pauseOnFailureIfRequested pauses the suite at the moment a failure is identified,
+// when the user has set --sleep-on-failure.  This hooks directly into runNode's failure
+// path so the pause happens immediately at the point of failure - before any teardown
+// or cleanup runs - leaving the system live for inspection.
+//
+// We only pause for failures in setup and subject nodes (It, Before*, BeforeSuite...),
+// i.e. nodes that run before teardown.  Pausing on a failure in a teardown/cleanup or
+// reporting node would be pointless (the system is already being torn down) and could
+// interfere with interrupt handling, so those are skipped.
+//
+// The pause is interruptible: pressing ^C (or any interrupt) ends the pause early and
+// the suite proceeds to run cleanup as usual.  It is a no-op if the feature is disabled.
+func (suite *Suite) pauseOnFailureIfRequested(node Node) {
+	if suite.config.SleepOnFailure <= 0 {
+		return
+	}
+	// only pause before teardown - skip teardown/cleanup/reporting nodes
+	if node.NodeType.Is(types.NodeTypesAllowedDuringCleanupInterrupt | types.NodeTypesAllowedDuringReportInterrupt) {
+		return
+	}
+
+	duration := suite.config.SleepOnFailure
+	report := suite.generateProgressReport(false)
+	report.Message = fmt.Sprintf("{{bold}}{{orange}}Paused on failure for up to %s.{{/}}\nThe spec failed and Ginkgo has paused before running any teardown so you can inspect the live system.\nPress {{bold}}^C{{/}} to end the pause and proceed to cleanup.", duration)
+	suite.emitProgressReport(report)
+
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	// wait for the pause to elapse, or for the user to interrupt - in which case we end
+	// the pause early and let runNode return so cleanup can proceed
+	select {
+	case <-timer.C:
+	case <-suite.interruptHandler.Status().Channel:
 	}
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -38,6 +38,7 @@ type SuiteConfig struct {
 	OutputInterceptorMode string
 	SourceRoots           []string
 	GracePeriod           time.Duration
+	SleepOnFailure        time.Duration
 
 	ParallelProcess int
 	ParallelTotal   int
@@ -293,6 +294,8 @@ var SuiteConfigFlags = GinkgoFlags{
 		Usage: "Make up to this many attempts to run each spec. If any of the attempts succeed, the suite will not be failed."},
 	{KeyPath: "S.FailOnEmpty", Name: "fail-on-empty", SectionKey: "failure",
 		Usage: "If set, ginkgo will mark the test suite as failed if no specs are run."},
+	{KeyPath: "S.SleepOnFailure", Name: "sleep-on-failure", SectionKey: "failure", UsageDefaultValue: "0 - disabled",
+		Usage: "If set, ginkgo will pause for this duration after a spec fails - before its teardown (AfterEach/JustAfterEach/DeferCleanup) runs - so you can inspect the live system. Press ^C to end the pause early and proceed to cleanup. Serial only: cannot be combined with -p/--procs."},
 
 	{KeyPath: "S.DryRun", Name: "dry-run", SectionKey: "debug", DeprecatedName: "dryRun", DeprecatedDocLink: "changed-command-line-flags",
 		Usage: "If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v."},
@@ -427,6 +430,14 @@ func VetConfig(flagSet GinkgoFlagSet, suiteConfig SuiteConfig, reporterConfig Re
 
 	if suiteConfig.GracePeriod <= 0 {
 		errors = append(errors, GinkgoErrors.GracePeriodCannotBeZero())
+	}
+
+	if suiteConfig.SleepOnFailure < 0 {
+		errors = append(errors, GinkgoErrors.InvalidSleepOnFailureConfiguration())
+	}
+
+	if suiteConfig.SleepOnFailure > 0 && suiteConfig.ParallelTotal > 1 {
+		errors = append(errors, GinkgoErrors.SleepOnFailureInParallelConfiguration())
 	}
 
 	if len(suiteConfig.FocusFiles) > 0 {

--- a/types/errors.go
+++ b/types/errors.go
@@ -455,7 +455,7 @@ func (g ginkgoErrors) InvalidEmptyComponentForSemVerConstraint(cl CodeLocation) 
 		Heading:      "Invalid Empty Component for ComponentSemVerConstraint",
 		Message:      "ComponentSemVerConstraint requires a non-empty component name",
 		CodeLocation: cl,
-		DocLink: "spec-semantic-version-filtering",
+		DocLink:      "spec-semantic-version-filtering",
 	}
 }
 
@@ -618,6 +618,21 @@ func (g ginkgoErrors) GracePeriodCannotBeZero() error {
 	return GinkgoError{
 		Heading: "Ginkgo requires a positive --grace-period.",
 		Message: "Please set --grace-period to a positive duration.  The default is 30s.",
+	}
+}
+
+func (g ginkgoErrors) InvalidSleepOnFailureConfiguration() error {
+	return GinkgoError{
+		Heading: "Ginkgo requires a non-negative --sleep-on-failure.",
+		Message: "Please set --sleep-on-failure to a positive duration (e.g. 5m), or 0 to disable it.",
+	}
+}
+
+func (g ginkgoErrors) SleepOnFailureInParallelConfiguration() error {
+	return GinkgoError{
+		Heading: "Ginkgo only supports --sleep-on-failure in serial mode.",
+		Message: "--sleep-on-failure pauses a failed spec on a live system for inspection, which only makes sense when the suite runs serially.  Please run again without -p or --procs, or unset --sleep-on-failure.",
+		DocLink: "spec-timeouts-and-interruptible-nodes",
 	}
 }
 


### PR DESCRIPTION
Closes #1671

## What

Adds a `--sleep-on-failure=<duration>` flag (default `0` = off). The moment a spec fails, Ginkgo pauses for the configured duration **before** any teardown (`AfterEach`/`JustAfterEach`/`DeferCleanup`) runs, so you can inspect the live system before its state is torn down.

## Why

When a spec fails against a real environment (cluster, DB, service), teardown destroys the very state you need to debug the failure. The existing building block (`time.Sleep` in a top-level `JustAfterEach`) works but isn't runtime-configurable. This packages that need as a first-class, well-behaved flag.

## How

Per the review feedback, this hooks directly into the suite's existing failure-handling path rather than injecting any nodes:

- In `runNode`, when a node finishes with a failure, Ginkgo emits the failure as it already does and then — if `--sleep-on-failure` is set — pauses right there, before returning to the spec loop (and therefore before any teardown runs). It emits a progress report with the helper text telling you the suite is paused and what to do.
- Only failures in **setup and subject nodes** (`It`, `Before*`, `BeforeSuite`...) pause. Failures in teardown/cleanup or reporting nodes are skipped, since the system is already being torn down at that point. This is implemented by skipping `NodeTypesAllowedDuringCleanupInterrupt | NodeTypesAllowedDuringReportInterrupt`.
- The pause `select`s on a timer and `interruptHandler.Status().Channel`, so the pause is **interruptible**: pressing `^C` ends it early and the suite proceeds to run cleanup as usual rather than skipping it.

This addresses the three points raised in #1671:

1. **Clear messaging** — the failure is emitted, followed by a progress report telling you the suite is paused and to press `^C` to proceed to cleanup.
2. **`^C` proceeds to cleanup** — the pause ends on interrupt and teardown then runs (covered by tests).
3. **Parallel** — since Ginkgo's parallelism is multi-process, a single failing spec can't meaningfully freeze the whole system. Rather than pretend otherwise, combining `--sleep-on-failure` with `-p`/`--procs` is rejected with a configuration error. This is intended as a serial debugging aid; run the failing spec serially (e.g. with `--focus`).

Also updates godoc and `docs/index.md` (under the interrupt/grace-period material).

## Test plan

- [x] `go vet ./...` passes
- [x] New `internal/internal_integration` tests: pause happens at the point of failure before teardown, setup-node (`BeforeEach`) failures pause, teardown-node failures do **not** pause, `^C` ends the pause and cleanup still runs, passing specs are never paused, and the flag is a no-op when `0`
- [x] New `integration` (CLI subprocess) tests: serial run waits ~the configured duration with ordering `failing body → pause notice → teardown`; parallel run exits with the serial-only error and does not hang
- [x] Full suite passes (`go test ./...`)