### PR TITLE
junit: support ReportEntry

### DIFF
--- a/reporters/__snapshots__/junit_report_test.snap
+++ b/reporters/__snapshots__/junit_report_test.snap
@@ -29,11 +29,19 @@
           <testcase name="[It] A B C [dolphin, gorilla, cow, cat, dog]" classname="My Suite" status="timedout" time="1">
               <failure message="failure&#xA;message" type="timedout">[TIMEDOUT] failure&#xA;message&#xA;In [It] at: cl3.go:103 @ 09/09/25 10:50:00&#xA;&#xA;[PANICKED] &#xA;In [It] at: cl4.go:144 @ 09/09/25 10:50:00&#xA;&#xA;the panic!&#xA;&#xA;Full Stack Trace&#xA;  full-trace&#xA;  cl-4&#xA;&#xA;There were additional failures detected after the initial failure. These are visible in the timeline&#xA;</failure>
               <system-out>some captured stdout&#xA;</system-out>
-              <system-err>STEP: a by step - cl0.go:12 @ 09/09/25 10:50:00&#xA;&gt; Enter [It] C - cl2.go:80 @ 09/09/25 10:50:00&#xA;ginkgowriter&#xA;[TIMEDOUT] failure&#xA;message&#xA;In [It] at: cl3.go:103 @ 09/09/25 10:50:00&#xA;output&#xA;[PANICKED] &#xA;In [It] at: cl4.go:144 @ 09/09/25 10:50:00&#xA;&#xA;the panic!&#xA;&#xA;Full Stack Trace&#xA;  full-trace&#xA;  cl-4&#xA;&lt; Exit [It] C - cl2.go:80 @ 09/09/25 10:50:00 (87ms)&#xA;a report entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;a hidden report entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;cleanup!&#xA;[FAILED] a subsequent failure&#xA;In [AfterEach] at: :0 @ 09/09/25 10:50:00&#xA;</system-err>
+              <system-err>STEP: a by step - cl0.go:12 @ 09/09/25 10:50:00&#xA;&gt; Enter [It] C - cl2.go:80 @ 09/09/25 10:50:00&#xA;ginkgowriter&#xA;[TIMEDOUT] failure&#xA;message&#xA;In [It] at: cl3.go:103 @ 09/09/25 10:50:00&#xA;output&#xA;[PANICKED] &#xA;In [It] at: cl4.go:144 @ 09/09/25 10:50:00&#xA;&#xA;the panic!&#xA;&#xA;Full Stack Trace&#xA;  full-trace&#xA;  cl-4&#xA;&lt; Exit [It] C - cl2.go:80 @ 09/09/25 10:50:00 (87ms)&#xA;a report entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;  report entry value&#xA;a hidden report entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;  hidden report entry value&#xA;cleanup!&#xA;[FAILED] a subsequent failure&#xA;In [AfterEach] at: :0 @ 09/09/25 10:50:00&#xA;</system-err>
+              <properties>
+                  <property name="a report entry" value="&#34;report entry value&#34;"></property>
+                  <property name="a hidden report entry" value="&#34;hidden report entry value&#34;"></property>
+              </properties>
           </testcase>
           <testcase name="[It] A [cat, owner:frank, OWNer:bob]" classname="My Suite" status="passed" time="1" owner="bob">
               <system-out>some captured stdout&#xA;</system-out>
-              <system-err>&gt; Enter [It] A - cl0.go:12 @ 09/09/25 10:50:00&#xA;some GinkgoWriter&#xA;my progress report&#xA;  A (Spec Runtime: 5s)&#xA;    cl0.go:12&#xA;STEP: My Step - cl1.go:37 @ 09/09/25 10:50:00&#xA;output is interspersed&#xA;my entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;my hidden entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;END STEP: My Step - cl1.go:37 @ 09/09/25 10:50:00 (200ms)&#xA;here and there&#xA;&lt; Exit [It] A - cl0.go:12 @ 09/09/25 10:50:00 (300ms)&#xA;</system-err>
+              <system-err>&gt; Enter [It] A - cl0.go:12 @ 09/09/25 10:50:00&#xA;some GinkgoWriter&#xA;my progress report&#xA;  A (Spec Runtime: 5s)&#xA;    cl0.go:12&#xA;STEP: My Step - cl1.go:37 @ 09/09/25 10:50:00&#xA;output is interspersed&#xA;my entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;  my entry value: 17&#xA;my hidden entry - cl1.go:37 @ 09/09/25 10:50:00&#xA;  my hidden entry value&#xA;END STEP: My Step - cl1.go:37 @ 09/09/25 10:50:00 (200ms)&#xA;here and there&#xA;&lt; Exit [It] A - cl0.go:12 @ 09/09/25 10:50:00 (300ms)&#xA;</system-err>
+              <properties>
+                  <property name="my entry" value="{&#34;Label&#34;:&#34;my entry value&#34;,&#34;Count&#34;:17}"></property>
+                  <property name="my hidden entry" value="&#34;my hidden entry value&#34;"></property>
+              </properties>
           </testcase>
           <testcase name="[It] A [owner:org, owner:team]" classname="My Suite" status="pending" time="1" owner="team">
               <skipped message="pending"></skipped>

--- a/reporters/junit_report.go
+++ b/reporters/junit_report.go
@@ -11,6 +11,7 @@ The schema used for the generated JUnit xml file was adapted from https://llg.cu
 package reporters
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"maps"
@@ -136,6 +137,8 @@ type JUnitTestCase struct {
 	SystemOut string `xml:"system-out,omitempty"`
 	//SystemOut maps onto any captured GinkgoWriter output - maps onto SpecReport.CapturedGinkgoWriterOutput
 	SystemErr string `xml:"system-err,omitempty"`
+	//Properties captures any ReportEntries attached to the spec via AddReportEntry, as key/value pairs with the JSON dump of the value as value.
+	Properties *JUnitProperties `xml:"properties,omitempty"`
 }
 
 type JUnitSkipped struct {
@@ -240,6 +243,20 @@ func GenerateJUnitReportWithConfig(report types.Report, dst string, config Junit
 		}
 		if !config.OmitCapturedStdOutErr {
 			test.SystemOut = systemOutForUnstructuredReporters(spec)
+		}
+		if len(spec.ReportEntries) > 0 {
+			properties := JUnitProperties{}
+			for _, entry := range spec.ReportEntries {
+				value, err := json.Marshal(entry.GetRawValue())
+				if err != nil {
+					value = []byte(fmt.Sprintf("%q", err.Error()))
+				}
+				properties.Properties = append(properties.Properties, JUnitProperty{
+					Name:  entry.Name,
+					Value: string(value),
+				})
+			}
+			test.Properties = &properties
 		}
 		suite.Tests += 1
 

--- a/reporters/junit_report_test.go
+++ b/reporters/junit_report_test.go
@@ -17,6 +17,17 @@ import (
 	"github.com/onsi/ginkgo/v2/types"
 )
 
+// reportEntryStringerValue is used as a ReportEntry value to demonstrate that the JUnit
+// "properties" element stores a JSON dump of the value, not its String() representation.
+type reportEntryStringerValue struct {
+	Label string
+	Count int
+}
+
+func (v reportEntryStringerValue) String() string {
+	return fmt.Sprintf("%s: %d", v.Label, v.Count)
+}
+
 var _ = Describe("JunitReport", func() {
 	var report types.Report
 
@@ -32,16 +43,16 @@ var _ = Describe("JunitReport", func() {
 					SE(types.SpecEventNodeStart, types.NodeTypeIt, "C", cl2, TL(0)),
 					F("failure\nmessage", cl3, types.FailureNodeIsLeafNode, FailureNodeLocation(cl2), types.NodeTypeIt, TL("ginkgowriter\n"), AF(types.SpecStatePanicked, cl4, types.FailureNodeIsLeafNode, FailureNodeLocation(cl2), types.NodeTypeIt, TL("ginkgowriter\noutput\n"), ForwardedPanic("the panic!"))),
 					SE(types.SpecEventNodeEnd, types.NodeTypeIt, "C", cl2, TL("ginkgowriter\noutput\n"), time.Microsecond*87230),
-					RE("a report entry", cl1, TL("ginkgowriter\noutput\n")),
-					RE("a hidden report entry", cl1, TL("ginkgowriter\noutput\n"), types.ReportEntryVisibilityNever),
+					RE("a report entry", cl1, TL("ginkgowriter\noutput\n"), "report entry value"),
+					RE("a hidden report entry", cl1, TL("ginkgowriter\noutput\n"), types.ReportEntryVisibilityNever, "hidden report entry value"),
 					AF(types.SpecStateFailed, "a subsequent failure", types.FailureNodeInContainer, FailureNodeLocation(cl3), types.NodeTypeAfterEach, 0, TL("ginkgowriter\noutput\ncleanup!")),
 				),
 				S(types.NodeTypeIt, "A", cl0, STD("some captured stdout\n"), GW("some GinkgoWriter\noutput is interspersed\nhere and there\n"), Label("cat", "owner:frank", "OWNer:bob"),
 					SE(types.SpecEventNodeStart, types.NodeTypeIt, "A", cl0),
 					PR("my progress report", LeafNodeText("A"), TL("some GinkgoWriter\n")),
 					SE(types.SpecEventByStart, "My Step", cl1, TL("some GinkgoWriter\n")),
-					RE("my entry", cl1, types.ReportEntryVisibilityFailureOrVerbose, TL("some GinkgoWriter\noutput is interspersed\n")),
-					RE("my hidden entry", cl1, types.ReportEntryVisibilityNever, TL("some GinkgoWriter\noutput is interspersed\n")),
+					RE("my entry", cl1, types.ReportEntryVisibilityFailureOrVerbose, TL("some GinkgoWriter\noutput is interspersed\n"), reportEntryStringerValue{Label: "my entry value", Count: 17}),
+					RE("my hidden entry", cl1, types.ReportEntryVisibilityNever, TL("some GinkgoWriter\noutput is interspersed\n"), "my hidden entry value"),
 					SE(types.SpecEventByEnd, "My Step", cl1, time.Millisecond*200, TL("some GinkgoWriter\noutput is interspersed\n")),
 					SE(types.SpecEventNodeEnd, types.NodeTypeIt, "A", cl0, time.Millisecond*300, TL("some GinkgoWriter\noutput is interspersed\nhere and there\n")),
 				),
@@ -137,7 +148,9 @@ var _ = Describe("JunitReport", func() {
 				"  cl-4",
 				spr("< Exit [It] C - cl2.go:80 @ %s (87ms)", FORMATTED_TIME),
 				spr("a report entry - cl1.go:37 @ %s", FORMATTED_TIME),
+				"  report entry value",
 				spr("a hidden report entry - cl1.go:37 @ %s", FORMATTED_TIME),
+				"  hidden report entry value",
 				"cleanup!",
 				"[FAILED] a subsequent failure",
 				spr("In [AfterEach] at: :0 @ %s", FORMATTED_TIME),
@@ -162,7 +175,9 @@ var _ = Describe("JunitReport", func() {
 				spr("STEP: My Step - cl1.go:37 @ %s", FORMATTED_TIME),
 				"output is interspersed",
 				spr("my entry - cl1.go:37 @ %s", FORMATTED_TIME),
+				"  my entry value: 17",
 				spr("my hidden entry - cl1.go:37 @ %s", FORMATTED_TIME),
+				"  my hidden entry value",
 				spr("END STEP: My Step - cl1.go:37 @ %s (200ms)", FORMATTED_TIME),
 				"here and there",
 				spr("< Exit [It] A - cl0.go:12 @ %s (300ms)", FORMATTED_TIME),
@@ -316,7 +331,9 @@ var _ = Describe("JunitReport", func() {
 				"  cl-4",
 				spr("< Exit [It] C - cl2.go:80 @ %s (87ms)", FORMATTED_TIME),
 				spr("a report entry - cl1.go:37 @ %s", FORMATTED_TIME),
+				"  report entry value",
 				spr("a hidden report entry - cl1.go:37 @ %s", FORMATTED_TIME),
+				"  hidden report entry value",
 				"cleanup!",
 				"[FAILED] a subsequent failure",
 				spr("In [AfterEach] at: :0 @ %s", FORMATTED_TIME),


### PR DESCRIPTION
Some JUnit tools support a "properties" element at the "testcase" level. This can be used to stored the ReportEntries attached to a spec. The string representation was chosen because the JUnit format seems to imply that this meant to be human-readable.
